### PR TITLE
Use /tmp for cache storage, scope entries by repo

### DIFF
--- a/server/cache.ts
+++ b/server/cache.ts
@@ -1,11 +1,7 @@
 import { join } from "path";
-import { homedir } from "os";
+import { tmpdir } from "os";
 import { mkdirSync, existsSync, readdirSync, unlinkSync, readFileSync } from "fs";
-import type { OutputHandler } from "../output";
 import type { RunContext } from "./types";
-
-const CACHE_DIR = join(homedir(), ".localrunner", "cache");
-const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 interface CacheEntry {
   key: string;
@@ -18,51 +14,34 @@ interface CacheEntry {
 
 let nextCacheId = Date.now();
 
-function getCacheDir(): string {
-  mkdirSync(CACHE_DIR, { recursive: true });
-  return CACHE_DIR;
+function getCacheDir(repo: string): string {
+  const dir = join(tmpdir(), "localrunner", "cache", repo);
+  mkdirSync(dir, { recursive: true });
+  return dir;
 }
 
-function cacheEntryPath(cacheId: number): string {
-  return join(getCacheDir(), `cache-${cacheId}`);
+function cacheEntryPath(repo: string, cacheId: number): string {
+  return join(getCacheDir(repo), `cache-${cacheId}`);
 }
 
-function cacheMetaPath(cacheId: number): string {
-  return join(getCacheDir(), `cache-${cacheId}.json`);
+function cacheMetaPath(repo: string, cacheId: number): string {
+  return join(getCacheDir(repo), `cache-${cacheId}.json`);
 }
 
-function isCacheExpired(entry: CacheEntry): boolean {
-  return Date.now() - new Date(entry.createdAt).getTime() > CACHE_TTL_MS;
+function removeCacheEntry(repo: string, cacheId: number): void {
+  try { unlinkSync(cacheEntryPath(repo, cacheId)); } catch {}
+  try { unlinkSync(cacheMetaPath(repo, cacheId)); } catch {}
 }
 
-function removeCacheEntry(cacheId: number): void {
-  try { unlinkSync(cacheEntryPath(cacheId)); } catch {}
-  try { unlinkSync(cacheMetaPath(cacheId)); } catch {}
-}
-
-export function evictExpiredCaches(output: OutputHandler): void {
-  const dir = getCacheDir();
-  for (const f of readdirSync(dir).filter(f => f.endsWith(".json"))) {
-    try {
-      const meta: CacheEntry = JSON.parse(readFileSync(join(dir, f), "utf8"));
-      if (isCacheExpired(meta)) {
-        const cacheId = parseInt(f.replace("cache-", "").replace(".json", ""));
-        removeCacheEntry(cacheId);
-        output.emit({ type: "server", tag: "cache", message: `Evicted expired entry: ${meta.key}` });
-      }
-    } catch {}
-  }
-}
-
-function findCache(keys: string[], version: string): { cacheId: number; entry: CacheEntry } | null {
-  const dir = getCacheDir();
+function findCache(repo: string, keys: string[], version: string): { cacheId: number; entry: CacheEntry } | null {
+  const dir = getCacheDir(repo);
   const metaFiles = readdirSync(dir).filter(f => f.endsWith(".json"));
 
   for (const key of keys) {
     for (const metaFile of metaFiles) {
       try {
         const meta: CacheEntry = JSON.parse(readFileSync(join(dir, metaFile), "utf8"));
-        if (!meta.committed || isCacheExpired(meta)) continue;
+        if (!meta.committed) continue;
         if (meta.key === key && meta.version === version) {
           const cacheId = parseInt(metaFile.replace("cache-", "").replace(".json", ""));
           return { cacheId, entry: meta };
@@ -75,7 +54,7 @@ function findCache(keys: string[], version: string): { cacheId: number; entry: C
     for (const metaFile of metaFiles) {
       try {
         const meta: CacheEntry = JSON.parse(readFileSync(join(dir, metaFile), "utf8"));
-        if (!meta.committed || isCacheExpired(meta)) continue;
+        if (!meta.committed) continue;
         if (meta.key.startsWith(key) && meta.version === version) {
           const cacheId = parseInt(metaFile.replace("cache-", "").replace(".json", ""));
           return { cacheId, entry: meta };
@@ -88,6 +67,8 @@ function findCache(keys: string[], version: string): { cacheId: number; entry: C
 }
 
 export function cacheRoutes(ctx: RunContext) {
+  const repo = ctx.repoCtx.fullName;
+
   return {
     "/_apis/artifactcache/cache": {
       GET: (req: Request) => {
@@ -96,7 +77,7 @@ export function cacheRoutes(ctx: RunContext) {
         const version = url.searchParams.get("version") || "";
         ctx.output.emit({ type: "server", tag: "cache", message: `Lookup keys=${keys.join(",")} version=${version.slice(0, 12)}` });
 
-        const found = findCache(keys, version);
+        const found = findCache(repo, keys, version);
         if (found) {
           ctx.output.emit({ type: "server", tag: "cache", message: `Hit: ${found.entry.key} (id=${found.cacheId})` });
           return Response.json({
@@ -115,7 +96,7 @@ export function cacheRoutes(ctx: RunContext) {
     "/_apis/artifactcache/download/:id": {
       GET: (req: Request & { params: { id: string } }) => {
         const cacheId = parseInt(req.params.id);
-        const filePath = cacheEntryPath(cacheId);
+        const filePath = cacheEntryPath(repo, cacheId);
         ctx.output.emit({ type: "server", tag: "cache", message: `Download id=${cacheId}` });
         if (existsSync(filePath)) {
           const file = Bun.file(filePath);
@@ -137,11 +118,11 @@ export function cacheRoutes(ctx: RunContext) {
           key: body.key,
           version: body.version || "",
           committed: false,
-          filePath: cacheEntryPath(cacheId),
+          filePath: cacheEntryPath(repo, cacheId),
           size: 0,
           createdAt: new Date().toISOString(),
         };
-        await Bun.write(cacheMetaPath(cacheId), JSON.stringify(entry));
+        await Bun.write(cacheMetaPath(repo, cacheId), JSON.stringify(entry));
         ctx.output.emit({ type: "server", tag: "cache", message: `Reserved id=${cacheId} key=${body.key}` });
         return Response.json({ cacheId });
       },
@@ -150,7 +131,7 @@ export function cacheRoutes(ctx: RunContext) {
       PATCH: async (req: Request & { params: { id: string } }) => {
         const cacheId = parseInt(req.params.id);
         const data = await req.arrayBuffer();
-        const filePath = cacheEntryPath(cacheId);
+        const filePath = cacheEntryPath(repo, cacheId);
         const contentRange = req.headers.get("Content-Range");
         ctx.output.emit({ type: "server", tag: "cache", message: `Upload id=${cacheId} size=${data.byteLength} range=${contentRange || "full"}` });
 
@@ -176,14 +157,14 @@ export function cacheRoutes(ctx: RunContext) {
       POST: async (req: Request & { params: { id: string } }) => {
         const cacheId = parseInt(req.params.id);
         const body = (await req.json()) as any;
-        const metaPath = cacheMetaPath(cacheId);
+        const metaPath = cacheMetaPath(repo, cacheId);
 
         if (existsSync(metaPath)) {
           const meta: CacheEntry = JSON.parse(readFileSync(metaPath, "utf8"));
           meta.committed = true;
           meta.size = body.size || 0;
 
-          const dir = getCacheDir();
+          const dir = getCacheDir(repo);
           for (const f of readdirSync(dir).filter(f => f.endsWith(".json"))) {
             const fPath = join(dir, f);
             if (fPath === metaPath) continue;
@@ -191,7 +172,7 @@ export function cacheRoutes(ctx: RunContext) {
               const existing: CacheEntry = JSON.parse(readFileSync(fPath, "utf8"));
               if (existing.key === meta.key && existing.version === meta.version) {
                 const oldId = parseInt(f.replace("cache-", "").replace(".json", ""));
-                removeCacheEntry(oldId);
+                removeCacheEntry(repo, oldId);
               }
             } catch {}
           }

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,7 +2,7 @@ import { createRunContext } from "./types";
 import type { ServerConfig, ServerHandle } from "./types";
 import { authRoutes } from "./auth";
 import { jobRoutes } from "./job";
-import { cacheRoutes, evictExpiredCaches } from "./cache";
+import { cacheRoutes } from "./cache";
 import { actionsHandler } from "./actions";
 import { resultsHandler } from "./results";
 import { logsHandler, websocketHandlers } from "./logs";
@@ -13,9 +13,6 @@ export type { ServerConfig, ServerHandle } from "./types";
 export function createServer(config: ServerConfig): ServerHandle {
   const { ctx, jobCompleted } = createRunContext(config);
   const { output } = ctx;
-
-  // Clean up expired cache entries on startup
-  evictExpiredCaches(output);
 
   // Build wildcard handlers (for paths with dynamic segments the router can't match)
   const handleActions = actionsHandler(ctx);


### PR DESCRIPTION
## Summary
- Move cache storage from `~/.localrunner/cache/` to `$TMPDIR/localrunner/cache/<owner>/<repo>/`, letting the OS handle cleanup instead of a 7-day TTL
- Scope cache entries by repository (`owner/repo` subdirectory) so different repos don't share cache
- Remove TTL expiration logic and startup eviction

## Test plan
- [ ] Run a workflow with `actions/cache` and verify cache is written to `/tmp/localrunner/cache/<owner>/<repo>/`
- [ ] Run the same workflow again and verify cache hit
- [ ] Run a workflow in a different repo and verify cache isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)