### PR TITLE
Add webhook event registry with 39 GitHub Actions events

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -3,7 +3,7 @@ import { parseArgs } from "util";
 import { join, resolve, basename } from "path";
 import { getRepoContext } from "./context";
 import { parseWorkflow, matchesEvent, normalizeOn, workflowStepsToRunnerSteps } from "./workflow";
-import { generateEventPayload } from "./events";
+import { generateEventPayload, EVENT_DEFINITIONS, EVENT_REGISTRY } from "./events";
 import { scriptStep, actionStep } from "./server/index";
 import { startRun } from "./orchestrator";
 import { buildExpressionContext, evaluateExpressions } from "./expressions";
@@ -29,6 +29,7 @@ const { values, positionals } = parseArgs({
     port: { type: "string", default: "9637" },
     raw: { type: "boolean" },
     verbose: { type: "boolean", short: "v" },
+    "list-events": { type: "boolean" },
     help: { type: "boolean", short: "h" },
   },
   allowPositionals: true,
@@ -36,10 +37,19 @@ const { values, positionals } = parseArgs({
 });
 
 function printUsage() {
+  const common = ["push", "pull_request", "pull_request_target", "workflow_dispatch", "issues", "release", "schedule"];
+  const eventLines = common
+    .map((name) => EVENT_REGISTRY.get(name))
+    .filter(Boolean)
+    .map((def) => `  ${def!.name.padEnd(26)} ${def!.description}${def!.name === "push" ? " (default)" : ""}`)
+    .join("\n");
+
   console.log(`Usage: localrunner [event] [flags]
 
 Events:
-  push (default), pull_request, workflow_dispatch, etc.
+${eventLines}
+
+  Use --list-events to see all ${EVENT_REGISTRY.size} supported events.
 
 Flags:
   -W, --workflows <path>    Workflow file or directory (default: .github/workflows/)
@@ -68,13 +78,98 @@ Examples:
   localrunner push -s MY_SECRET=foo              # with secret`);
 }
 
+if (values.help && positionals[0]) {
+  // Event-specific help: bun cli.ts push --help
+  const name = positionals[0];
+  const def = EVENT_REGISTRY.get(name);
+  if (!def) {
+    console.error(`Unknown event: '${name}'. Run --list-events to see all supported events.`);
+    process.exit(1);
+  }
+
+  console.log(`Event: ${def.name}`);
+  console.log(`  ${def.description}\n`);
+
+  if (def.validActions.length > 0) {
+    console.log(`Activity types: ${def.validActions.join(", ")}`);
+    console.log(`Default: ${def.defaultAction}\n`);
+  }
+
+  const filters: string[] = [];
+  if (def.supportsFilters.branches) filters.push("branches");
+  if (def.supportsFilters.paths) filters.push("paths");
+  if (def.supportsFilters.tags) filters.push("tags");
+  if (filters.length > 0) {
+    console.log(`Filters: ${filters.join(", ")}\n`);
+  }
+
+  console.log(`Workflow usage:`);
+  if (def.validActions.length > 0) {
+    console.log(`  on:`);
+    console.log(`    ${def.name}:`);
+    console.log(`      types: [${def.validActions.slice(0, 3).join(", ")}]`);
+  } else {
+    console.log(`  on: [${def.name}]`);
+  }
+
+  // Generate and show sample payload
+  const { getRepoContext: getCtx } = await import("./context");
+  try {
+    const ctx = await getCtx();
+    const payload = await def.generatePayload(ctx);
+    console.log(`\nSample payload (github.event):`);
+    console.log(JSON.stringify(payload, null, 2));
+  } catch {
+    // Fall back to a stub context if git/gh isn't available
+    const stubCtx = {
+      owner: "owner", repo: "repo", fullName: "owner/repo",
+      defaultBranch: "main", sha: "abc123", ref: "refs/heads/main",
+      remoteUrl: "https://github.com/owner/repo", token: "",
+      actor: "user", actorId: "1", repositoryId: "1",
+      repositoryOwnerId: "1", serverUrl: "https://github.com",
+      apiUrl: "https://api.github.com", graphqlUrl: "https://api.github.com/graphql",
+    };
+    const payload = await def.generatePayload(stubCtx);
+    console.log(`\nSample payload (github.event):`);
+    console.log(JSON.stringify(payload, null, 2));
+  }
+
+  console.log(`\nOverride with: localrunner ${def.name} -e payload.json`);
+  process.exit(0);
+}
+
 if (values.help) {
   printUsage();
   process.exit(0);
 }
 
+if (values["list-events"]) {
+  for (const def of EVENT_DEFINITIONS) {
+    console.log(def.name);
+    console.log(`  ${def.description}`);
+    if (def.validActions.length > 0) {
+      console.log(`  Activity types: ${def.validActions.join(", ")}`);
+      console.log(`  Default: ${def.defaultAction}`);
+    }
+    const filters: string[] = [];
+    if (def.supportsFilters.branches) filters.push("branches");
+    if (def.supportsFilters.paths) filters.push("paths");
+    if (def.supportsFilters.tags) filters.push("tags");
+    if (filters.length > 0) {
+      console.log(`  Filters: ${filters.join(", ")}`);
+    }
+    console.log();
+  }
+  process.exit(0);
+}
+
 // Event name: first positional or default to "push"
 const eventName: string = positionals[0] || "push";
+
+if (!EVENT_REGISTRY.has(eventName)) {
+  console.warn(`Warning: '${eventName}' is not a recognized GitHub Actions event. Using minimal payload.`);
+  console.warn(`Run with --list-events to see all supported events.`);
+}
 
 const port = parseInt(values.port || "9637", 10);
 

--- a/events.test.ts
+++ b/events.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe } from "bun:test";
-import { generateEventPayload } from "./events";
+import { generateEventPayload, EVENT_DEFINITIONS, EVENT_REGISTRY } from "./events";
 import type { RepoContext } from "./context";
 
 const mockCtx: RepoContext = {
@@ -48,7 +48,7 @@ describe("generateEventPayload", () => {
   });
 
   test("generates minimal payload for unknown events", async () => {
-    const payload = (await generateEventPayload("release", mockCtx)) as any;
+    const payload = (await generateEventPayload("custom_unknown_event", mockCtx)) as any;
     expect(payload.repository.full_name).toBe("testowner/testrepo");
     expect(payload.sender.login).toBe("testuser");
   });
@@ -59,5 +59,51 @@ describe("generateEventPayload", () => {
     })) as any;
     expect(payload.custom_field).toBe("custom_value");
     expect(payload.ref).toBe("refs/heads/main");
+  });
+});
+
+describe("EVENT_REGISTRY", () => {
+  test("all events have name and description", () => {
+    for (const def of EVENT_DEFINITIONS) {
+      expect(def.name).toBeTruthy();
+      expect(def.description).toBeTruthy();
+    }
+  });
+
+  test("registry has same count as definitions array", () => {
+    expect(EVENT_REGISTRY.size).toBe(EVENT_DEFINITIONS.length);
+  });
+
+  test("all events produce payloads with repository and sender", async () => {
+    for (const [name, def] of EVENT_REGISTRY) {
+      const payload = (await def.generatePayload(mockCtx)) as any;
+      expect(payload.repository).toBeDefined();
+      expect(payload.sender).toBeDefined();
+    }
+  });
+
+  test("action events include action field matching defaultAction", async () => {
+    for (const [name, def] of EVENT_REGISTRY) {
+      if (def.defaultAction) {
+        const payload = (await def.generatePayload(mockCtx)) as any;
+        expect(payload.action).toBe(def.defaultAction);
+      }
+    }
+  });
+
+  test("known events generate specific payloads via generateEventPayload", async () => {
+    const release = (await generateEventPayload("release", mockCtx)) as any;
+    expect(release.action).toBe("published");
+    expect(release.release).toBeDefined();
+    expect(release.release.tag_name).toBe("v1.0.0");
+
+    const issues = (await generateEventPayload("issues", mockCtx)) as any;
+    expect(issues.action).toBe("opened");
+    expect(issues.issue).toBeDefined();
+    expect(issues.issue.number).toBe(1);
+
+    const create = (await generateEventPayload("create", mockCtx)) as any;
+    expect(create.ref).toBe("main");
+    expect(create.ref_type).toBe("branch");
   });
 });

--- a/events.ts
+++ b/events.ts
@@ -1,7 +1,22 @@
 import type { RepoContext } from "./context";
 import { $ } from "bun";
 
-// --- Generate event payloads based on event type + local git state ---
+// --- Types ---
+
+export interface EventPayloadOptions {
+  inputDefaults?: Record<string, string>;
+}
+
+export interface EventDefinition {
+  name: string;
+  description: string;
+  defaultAction: string | null;
+  validActions: string[];
+  supportsFilters: { branches: boolean; paths: boolean; tags: boolean };
+  generatePayload: (ctx: RepoContext, options?: EventPayloadOptions) => Promise<object> | object;
+}
+
+// --- Git helpers ---
 
 async function getLatestCommitMessage(): Promise<string> {
   try {
@@ -27,6 +42,8 @@ async function getCurrentBranch(): Promise<string> {
   }
 }
 
+// --- Payload helpers ---
+
 function repoPayload(ctx: RepoContext) {
   return {
     id: Number(ctx.repositoryId),
@@ -49,6 +66,28 @@ function senderPayload(ctx: RepoContext) {
   };
 }
 
+function basePayload(ctx: RepoContext) {
+  return {
+    repository: repoPayload(ctx),
+    sender: senderPayload(ctx),
+  };
+}
+
+function entityPayload(
+  ctx: RepoContext,
+  action: string,
+  entityKey: string,
+  entityFields: Record<string, unknown> = {},
+) {
+  return {
+    action,
+    [entityKey]: { id: 1, node_id: "stub", ...entityFields },
+    ...basePayload(ctx),
+  };
+}
+
+// --- Custom payload generators ---
+
 async function generatePushPayload(ctx: RepoContext): Promise<object> {
   const [before, commitMsg] = await Promise.all([
     getPreviousSha(),
@@ -68,8 +107,7 @@ async function generatePushPayload(ctx: RepoContext): Promise<object> {
       timestamp: new Date().toISOString(),
       author: { name: ctx.actor, email: "", username: ctx.actor },
     },
-    repository: repoPayload(ctx),
-    sender: senderPayload(ctx),
+    ...basePayload(ctx),
   };
 }
 
@@ -96,20 +134,530 @@ async function generatePullRequestPayload(ctx: RepoContext): Promise<object> {
       user: senderPayload(ctx),
       html_url: `${ctx.serverUrl}/${ctx.fullName}/pull/1`,
     },
-    repository: repoPayload(ctx),
-    sender: senderPayload(ctx),
+    ...basePayload(ctx),
   };
 }
 
-function generateWorkflowDispatchPayload(ctx: RepoContext, inputDefaults?: Record<string, string>): object {
+function generateWorkflowDispatchPayload(ctx: RepoContext, opts?: EventPayloadOptions): object {
   return {
     ref: ctx.ref,
-    inputs: inputDefaults ?? {},
-    repository: repoPayload(ctx),
-    sender: senderPayload(ctx),
+    inputs: opts?.inputDefaults ?? {},
     workflow: "",
+    ...basePayload(ctx),
   };
 }
+
+// --- No-filter shorthand ---
+const noFilters = { branches: false, paths: false, tags: false };
+
+// --- Event definitions ---
+
+export const EVENT_DEFINITIONS: EventDefinition[] = [
+  // Custom generators
+  {
+    name: "push",
+    description: "Push to a branch or tag",
+    defaultAction: null,
+    validActions: [],
+    supportsFilters: { branches: true, paths: true, tags: true },
+    generatePayload: (ctx) => generatePushPayload(ctx),
+  },
+  {
+    name: "pull_request",
+    description: "Pull request activity",
+    defaultAction: "opened",
+    validActions: [
+      "opened", "edited", "closed", "reopened", "synchronize", "assigned", "unassigned",
+      "labeled", "unlabeled", "ready_for_review", "converted_to_draft", "locked", "unlocked",
+      "enqueued", "dequeued", "milestoned", "demilestoned", "review_requested",
+      "review_request_removed", "auto_merge_enabled", "auto_merge_disabled",
+    ],
+    supportsFilters: { branches: true, paths: true, tags: false },
+    generatePayload: (ctx) => generatePullRequestPayload(ctx),
+  },
+  {
+    name: "pull_request_target",
+    description: "Pull request activity (runs in base branch context)",
+    defaultAction: "opened",
+    validActions: [
+      "opened", "edited", "closed", "reopened", "synchronize", "assigned", "unassigned",
+      "labeled", "unlabeled", "ready_for_review", "converted_to_draft", "locked", "unlocked",
+      "enqueued", "dequeued", "milestoned", "demilestoned", "review_requested",
+      "review_request_removed", "auto_merge_enabled", "auto_merge_disabled",
+    ],
+    supportsFilters: { branches: true, paths: true, tags: false },
+    generatePayload: (ctx) => generatePullRequestPayload(ctx),
+  },
+  {
+    name: "workflow_dispatch",
+    description: "Manual workflow trigger with optional inputs",
+    defaultAction: null,
+    validActions: [],
+    supportsFilters: noFilters,
+    generatePayload: (ctx, opts) => generateWorkflowDispatchPayload(ctx, opts),
+  },
+
+  // Issue & PR comment events
+  {
+    name: "issues",
+    description: "Issue activity",
+    defaultAction: "opened",
+    validActions: [
+      "opened", "edited", "deleted", "pinned", "unpinned", "closed", "reopened",
+      "assigned", "unassigned", "labeled", "unlabeled", "locked", "unlocked",
+      "transferred", "milestoned", "demilestoned",
+    ],
+    supportsFilters: noFilters,
+    generatePayload: (ctx) => entityPayload(ctx, "opened", "issue", {
+      number: 1, title: "Test issue", state: "open",
+      html_url: `${ctx.serverUrl}/${ctx.fullName}/issues/1`,
+      user: senderPayload(ctx),
+    }),
+  },
+  {
+    name: "issue_comment",
+    description: "Comment on an issue or pull request",
+    defaultAction: "created",
+    validActions: ["created", "edited", "deleted"],
+    supportsFilters: noFilters,
+    generatePayload: (ctx) => ({
+      action: "created",
+      issue: { id: 1, number: 1, title: "Test issue", state: "open",
+        html_url: `${ctx.serverUrl}/${ctx.fullName}/issues/1`,
+        user: senderPayload(ctx) },
+      comment: { id: 1, body: "Test comment", user: senderPayload(ctx) },
+      ...basePayload(ctx),
+    }),
+  },
+  {
+    name: "pull_request_review",
+    description: "Pull request review submitted, edited, or dismissed",
+    defaultAction: "submitted",
+    validActions: ["submitted", "edited", "dismissed"],
+    supportsFilters: noFilters,
+    generatePayload: (ctx) => ({
+      action: "submitted",
+      review: { id: 1, state: "approved", body: "", user: senderPayload(ctx) },
+      pull_request: { number: 1, title: "Test PR", state: "open",
+        html_url: `${ctx.serverUrl}/${ctx.fullName}/pull/1`,
+        user: senderPayload(ctx) },
+      ...basePayload(ctx),
+    }),
+  },
+  {
+    name: "pull_request_review_comment",
+    description: "Comment on a pull request diff",
+    defaultAction: "created",
+    validActions: ["created", "edited", "deleted"],
+    supportsFilters: noFilters,
+    generatePayload: (ctx) => ({
+      action: "created",
+      comment: { id: 1, body: "Test comment", path: "file.txt", user: senderPayload(ctx) },
+      pull_request: { number: 1, title: "Test PR", state: "open",
+        html_url: `${ctx.serverUrl}/${ctx.fullName}/pull/1`,
+        user: senderPayload(ctx) },
+      ...basePayload(ctx),
+    }),
+  },
+  {
+    name: "pull_request_review_thread",
+    description: "Pull request comment thread resolved or unresolved",
+    defaultAction: "resolved",
+    validActions: ["resolved", "unresolved"],
+    supportsFilters: noFilters,
+    generatePayload: (ctx) => ({
+      action: "resolved",
+      thread: { id: 1, node_id: "stub" },
+      pull_request: { number: 1, title: "Test PR", state: "open",
+        html_url: `${ctx.serverUrl}/${ctx.fullName}/pull/1`,
+        user: senderPayload(ctx) },
+      ...basePayload(ctx),
+    }),
+  },
+
+  // Discussion events
+  {
+    name: "discussion",
+    description: "Discussion activity",
+    defaultAction: "created",
+    validActions: [
+      "created", "edited", "deleted", "transferred", "pinned", "unpinned",
+      "labeled", "unlabeled", "locked", "unlocked", "category_changed", "answered", "unanswered",
+    ],
+    supportsFilters: noFilters,
+    generatePayload: (ctx) => entityPayload(ctx, "created", "discussion", {
+      number: 1, title: "Test discussion",
+      html_url: `${ctx.serverUrl}/${ctx.fullName}/discussions/1`,
+      user: senderPayload(ctx),
+    }),
+  },
+  {
+    name: "discussion_comment",
+    description: "Comment on a discussion",
+    defaultAction: "created",
+    validActions: ["created", "edited", "deleted"],
+    supportsFilters: noFilters,
+    generatePayload: (ctx) => ({
+      action: "created",
+      discussion: { id: 1, number: 1, title: "Test discussion",
+        html_url: `${ctx.serverUrl}/${ctx.fullName}/discussions/1`,
+        user: senderPayload(ctx) },
+      comment: { id: 1, body: "Test comment", user: senderPayload(ctx) },
+      ...basePayload(ctx),
+    }),
+  },
+
+  // Ref lifecycle events
+  {
+    name: "create",
+    description: "Branch or tag created",
+    defaultAction: null,
+    validActions: [],
+    supportsFilters: noFilters,
+    generatePayload: (ctx) => ({
+      ref: ctx.ref.replace(/^refs\/(heads|tags)\//, ""),
+      ref_type: ctx.ref.startsWith("refs/tags/") ? "tag" : "branch",
+      master_branch: ctx.defaultBranch,
+      ...basePayload(ctx),
+    }),
+  },
+  {
+    name: "delete",
+    description: "Branch or tag deleted",
+    defaultAction: null,
+    validActions: [],
+    supportsFilters: noFilters,
+    generatePayload: (ctx) => ({
+      ref: ctx.ref.replace(/^refs\/(heads|tags)\//, ""),
+      ref_type: ctx.ref.startsWith("refs/tags/") ? "tag" : "branch",
+      ...basePayload(ctx),
+    }),
+  },
+
+  // Repository events
+  {
+    name: "fork",
+    description: "Repository forked",
+    defaultAction: null,
+    validActions: [],
+    supportsFilters: noFilters,
+    generatePayload: (ctx) => ({
+      forkee: {
+        id: 2,
+        full_name: `${ctx.actor}/${ctx.repo}`,
+        owner: senderPayload(ctx),
+        html_url: `${ctx.serverUrl}/${ctx.actor}/${ctx.repo}`,
+      },
+      ...basePayload(ctx),
+    }),
+  },
+  {
+    name: "gollum",
+    description: "Wiki page created or updated",
+    defaultAction: null,
+    validActions: [],
+    supportsFilters: noFilters,
+    generatePayload: (ctx) => ({
+      pages: [{ page_name: "Home", title: "Home", action: "created",
+        html_url: `${ctx.serverUrl}/${ctx.fullName}/wiki/Home` }],
+      ...basePayload(ctx),
+    }),
+  },
+  {
+    name: "public",
+    description: "Repository changed from private to public",
+    defaultAction: null,
+    validActions: [],
+    supportsFilters: noFilters,
+    generatePayload: (ctx) => basePayload(ctx),
+  },
+  {
+    name: "watch",
+    description: "Repository starred",
+    defaultAction: "started",
+    validActions: ["started"],
+    supportsFilters: noFilters,
+    generatePayload: (ctx) => ({ action: "started", ...basePayload(ctx) }),
+  },
+
+  // Label, milestone, project events
+  {
+    name: "label",
+    description: "Label created, edited, or deleted",
+    defaultAction: "created",
+    validActions: ["created", "edited", "deleted"],
+    supportsFilters: noFilters,
+    generatePayload: (ctx) => entityPayload(ctx, "created", "label", {
+      name: "bug", color: "d73a4a", description: "Something isn't working",
+    }),
+  },
+  {
+    name: "milestone",
+    description: "Milestone activity",
+    defaultAction: "created",
+    validActions: ["created", "closed", "opened", "edited", "deleted"],
+    supportsFilters: noFilters,
+    generatePayload: (ctx) => entityPayload(ctx, "created", "milestone", {
+      number: 1, title: "v1.0", state: "open",
+      html_url: `${ctx.serverUrl}/${ctx.fullName}/milestone/1`,
+    }),
+  },
+  {
+    name: "project",
+    description: "Classic project board activity",
+    defaultAction: "created",
+    validActions: ["created", "closed", "reopened", "edited", "deleted"],
+    supportsFilters: noFilters,
+    generatePayload: (ctx) => entityPayload(ctx, "created", "project", {
+      name: "Test project",
+      html_url: `${ctx.serverUrl}/${ctx.fullName}/projects/1`,
+    }),
+  },
+  {
+    name: "project_card",
+    description: "Classic project card activity",
+    defaultAction: "created",
+    validActions: ["created", "moved", "converted", "edited", "deleted"],
+    supportsFilters: noFilters,
+    generatePayload: (ctx) => entityPayload(ctx, "created", "project_card", {
+      note: "Test card",
+    }),
+  },
+  {
+    name: "project_column",
+    description: "Classic project column activity",
+    defaultAction: "created",
+    validActions: ["created", "updated", "moved", "deleted"],
+    supportsFilters: noFilters,
+    generatePayload: (ctx) => entityPayload(ctx, "created", "project_column", {
+      name: "To Do",
+    }),
+  },
+
+  // Release & registry
+  {
+    name: "release",
+    description: "Release published, edited, or deleted",
+    defaultAction: "published",
+    validActions: ["published", "unpublished", "created", "edited", "deleted", "prereleased", "released"],
+    supportsFilters: noFilters,
+    generatePayload: (ctx) => entityPayload(ctx, "published", "release", {
+      tag_name: "v1.0.0", name: "v1.0.0", draft: false, prerelease: false,
+      html_url: `${ctx.serverUrl}/${ctx.fullName}/releases/tag/v1.0.0`,
+      author: senderPayload(ctx),
+    }),
+  },
+  {
+    name: "registry_package",
+    description: "GitHub Packages activity",
+    defaultAction: "published",
+    validActions: ["published", "updated"],
+    supportsFilters: noFilters,
+    generatePayload: (ctx) => entityPayload(ctx, "published", "registry_package", {
+      name: ctx.repo, package_type: "container",
+    }),
+  },
+
+  // CI/CD events
+  {
+    name: "check_run",
+    description: "Check run activity",
+    defaultAction: "completed",
+    validActions: ["created", "completed", "rerequested", "requested_action"],
+    supportsFilters: noFilters,
+    generatePayload: (ctx) => entityPayload(ctx, "completed", "check_run", {
+      name: "test", head_sha: ctx.sha, status: "completed", conclusion: "success",
+      html_url: `${ctx.serverUrl}/${ctx.fullName}/runs/1`,
+    }),
+  },
+  {
+    name: "check_suite",
+    description: "Check suite activity",
+    defaultAction: "completed",
+    validActions: ["completed", "requested", "rerequested"],
+    supportsFilters: noFilters,
+    generatePayload: (ctx) => entityPayload(ctx, "completed", "check_suite", {
+      head_sha: ctx.sha, head_branch: ctx.ref.replace("refs/heads/", ""),
+      status: "completed", conclusion: "success",
+    }),
+  },
+  {
+    name: "deployment",
+    description: "Deployment created",
+    defaultAction: null,
+    validActions: [],
+    supportsFilters: noFilters,
+    generatePayload: (ctx) => ({
+      deployment: {
+        id: 1, node_id: "stub", sha: ctx.sha,
+        ref: ctx.ref, environment: "production",
+        creator: senderPayload(ctx),
+      },
+      ...basePayload(ctx),
+    }),
+  },
+  {
+    name: "deployment_status",
+    description: "Deployment status updated",
+    defaultAction: null,
+    validActions: [],
+    supportsFilters: noFilters,
+    generatePayload: (ctx) => ({
+      deployment_status: {
+        id: 1, node_id: "stub", state: "success",
+        environment: "production",
+        creator: senderPayload(ctx),
+      },
+      deployment: {
+        id: 1, node_id: "stub", sha: ctx.sha,
+        ref: ctx.ref, environment: "production",
+        creator: senderPayload(ctx),
+      },
+      ...basePayload(ctx),
+    }),
+  },
+  {
+    name: "status",
+    description: "Commit status updated",
+    defaultAction: null,
+    validActions: [],
+    supportsFilters: noFilters,
+    generatePayload: (ctx) => ({
+      sha: ctx.sha, state: "success", context: "default",
+      description: "", target_url: "",
+      ...basePayload(ctx),
+    }),
+  },
+  {
+    name: "page_build",
+    description: "GitHub Pages build completed",
+    defaultAction: null,
+    validActions: [],
+    supportsFilters: noFilters,
+    generatePayload: (ctx) => ({
+      build: { status: "built", error: { message: null } },
+      ...basePayload(ctx),
+    }),
+  },
+
+  // Branch protection & merge
+  {
+    name: "branch_protection_rule",
+    description: "Branch protection rule activity",
+    defaultAction: "created",
+    validActions: ["created", "edited", "deleted"],
+    supportsFilters: noFilters,
+    generatePayload: (ctx) => entityPayload(ctx, "created", "rule", {
+      name: ctx.defaultBranch,
+    }),
+  },
+  {
+    name: "merge_group",
+    description: "Merge queue activity",
+    defaultAction: "checks_requested",
+    validActions: ["checks_requested", "destroyed"],
+    supportsFilters: noFilters,
+    generatePayload: (ctx) => entityPayload(ctx, "checks_requested", "merge_group", {
+      head_sha: ctx.sha,
+      head_ref: `refs/heads/gh-readonly-queue/${ctx.defaultBranch}/pr-1`,
+      base_sha: ctx.sha,
+      base_ref: `refs/heads/${ctx.defaultBranch}`,
+    }),
+  },
+
+  // Workflow events
+  {
+    name: "workflow_run",
+    description: "Workflow run requested or completed",
+    defaultAction: "completed",
+    validActions: ["completed", "requested", "in_progress"],
+    supportsFilters: noFilters,
+    generatePayload: (ctx) => ({
+      action: "completed",
+      workflow_run: {
+        id: 1, node_id: "stub", name: "CI", head_sha: ctx.sha,
+        head_branch: ctx.ref.replace("refs/heads/", ""),
+        status: "completed", conclusion: "success",
+        html_url: `${ctx.serverUrl}/${ctx.fullName}/actions/runs/1`,
+      },
+      workflow: { id: 1, name: "CI", path: ".github/workflows/ci.yml" },
+      ...basePayload(ctx),
+    }),
+  },
+  {
+    name: "workflow_call",
+    description: "Reusable workflow called from another workflow",
+    defaultAction: null,
+    validActions: [],
+    supportsFilters: noFilters,
+    generatePayload: (ctx) => basePayload(ctx),
+  },
+  {
+    name: "repository_dispatch",
+    description: "Custom webhook event via API",
+    defaultAction: null,
+    validActions: [],
+    supportsFilters: noFilters,
+    generatePayload: (ctx) => ({
+      action: "",
+      client_payload: {},
+      ...basePayload(ctx),
+    }),
+  },
+  {
+    name: "schedule",
+    description: "Scheduled cron trigger",
+    defaultAction: null,
+    validActions: [],
+    supportsFilters: noFilters,
+    generatePayload: (ctx) => ({
+      schedule: "",
+      ...basePayload(ctx),
+    }),
+  },
+
+  // Security events
+  {
+    name: "code_scanning_alert",
+    description: "Code scanning alert activity",
+    defaultAction: "appeared_in_branch",
+    validActions: ["appeared_in_branch", "closed_by_user", "created", "fixed", "reopened", "reopened_by_user"],
+    supportsFilters: noFilters,
+    generatePayload: (ctx) => entityPayload(ctx, "appeared_in_branch", "alert", {
+      number: 1, state: "open",
+      rule: { id: "test-rule", severity: "warning" },
+      tool: { name: "test-tool" },
+    }),
+  },
+  {
+    name: "secret_scanning_alert",
+    description: "Secret scanning alert activity",
+    defaultAction: "created",
+    validActions: ["created", "resolved", "reopened", "validated"],
+    supportsFilters: noFilters,
+    generatePayload: (ctx) => entityPayload(ctx, "created", "alert", {
+      number: 1, secret_type: "test_secret",
+      html_url: `${ctx.serverUrl}/${ctx.fullName}/security/secret-scanning/1`,
+    }),
+  },
+  {
+    name: "dependabot_alert",
+    description: "Dependabot alert activity",
+    defaultAction: "created",
+    validActions: ["created", "dismissed", "fixed", "reintroduced", "reopened"],
+    supportsFilters: noFilters,
+    generatePayload: (ctx) => entityPayload(ctx, "created", "alert", {
+      number: 1, state: "open",
+      dependency: { package: { name: "test-package" } },
+    }),
+  },
+];
+
+export const EVENT_REGISTRY: Map<string, EventDefinition> = new Map(
+  EVENT_DEFINITIONS.map((e) => [e.name, e]),
+);
+
+// --- Public API ---
 
 export async function generateEventPayload(
   eventName: string,
@@ -117,24 +665,13 @@ export async function generateEventPayload(
   overrides?: object,
   inputDefaults?: Record<string, string>,
 ): Promise<object> {
-  let payload: object;
+  const definition = EVENT_REGISTRY.get(eventName);
 
-  switch (eventName) {
-    case "push":
-      payload = await generatePushPayload(ctx);
-      break;
-    case "pull_request":
-      payload = await generatePullRequestPayload(ctx);
-      break;
-    case "workflow_dispatch":
-      payload = generateWorkflowDispatchPayload(ctx, inputDefaults);
-      break;
-    default:
-      // For unknown events, provide minimal payload
-      payload = {
-        repository: repoPayload(ctx),
-        sender: senderPayload(ctx),
-      };
+  let payload: object;
+  if (definition) {
+    payload = await definition.generatePayload(ctx, { inputDefaults });
+  } else {
+    payload = basePayload(ctx);
   }
 
   if (overrides) {


### PR DESCRIPTION
## Summary
- Replace hardcoded switch statement in `events.ts` with an `EventDefinition` abstraction — each of 39 events declares its name, description, valid activity types, filter support, and payload generator
- Add `--list-events` flag to CLI showing all supported events with their details
- Add per-event help via `localrunner <event> --help` that displays activity types, workflow usage, and a full sample payload generated from the current repo
- Warn on unrecognized event names with pointer to `--list-events`

## Test plan
- [x] All 87 existing unit tests pass (`bun test`)
- [x] New registry tests: every event produces `repository`/`sender`, action events include correct `action` field
- [x] `localrunner --help` shows common events with descriptions
- [x] `localrunner --list-events` shows all 39 events
- [x] `localrunner push --help` shows sample payload
- [x] `localrunner release --help` shows activity types + payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)