### PR TITLE
Add website/public to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ actions-runner.tar.gz
 
 # Cursor
 .cursor/
+
+# Hugo
+website/public


### PR DESCRIPTION
## Summary
- Add `website/public` to `.gitignore` to exclude Hugo build output

🤖 Generated with [Claude Code](https://claude.com/claude-code)