### PR TITLE
Add worktrunk config for worktree setup

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,0 +1,2 @@
+[post-create]
+install = "bun install"


### PR DESCRIPTION
## Summary
- Adds `.config/wt.toml` with a `post-create` hook that runs `bun install` automatically when creating a new worktree

## Test plan
- [x] Create a new worktree with `wt switch --create <branch>` and verify `bun install` runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)