### PR TITLE
Restrict acceptance test triggers to PR synchronize and push to main

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -1,5 +1,9 @@
 name: Acceptance Tests
-on: [push, pull_request]
+on:
+  pull_request:
+    types: [synchronize]
+  push:
+    branches: [main]
 jobs:
   acceptance:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Replaces broad `[push, pull_request]` trigger with `pull_request: synchronize` and `push` to `main` only
- Prevents acceptance tests from running on every push to development branches or on PR open/reopen

Closes #23

## Test plan
- [ ] Verify acceptance tests trigger on push to main
- [ ] Verify acceptance tests trigger on PR synchronize (new commits pushed to PR)
- [ ] Verify acceptance tests do NOT trigger on regular branch pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)