### PR TITLE
Map runs-on labels to correct Docker images

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -298,12 +298,32 @@ async function main() {
     platformOverrides[p.slice(0, eq)] = p.slice(eq + 1);
   }
 
+  function resolveRunsOnImage(label: string): string | undefined {
+    // Exact match in defaults
+    if (DEFAULT_IMAGES[label]) return DEFAULT_IMAGES[label];
+
+    // Larger runner variants: ubuntu-latest-Xcores, ubuntu-24.04-Xcores, etc.
+    // Strip the trailing resource suffix (e.g. "-4-cores", "-16-cores") and retry
+    const withoutCores = label.replace(/-\d+-cores?$/, "");
+    if (withoutCores !== label && DEFAULT_IMAGES[withoutCores]) {
+      return DEFAULT_IMAGES[withoutCores];
+    }
+
+    // Match ubuntu version patterns like "ubuntu-22.04-anything"
+    if (label.startsWith("ubuntu-22.04")) return DEFAULT_IMAGES["ubuntu-22.04"];
+    if (label.startsWith("ubuntu-24.04") || label.startsWith("ubuntu-latest")) {
+      return DEFAULT_IMAGES["ubuntu-latest"];
+    }
+
+    return undefined;
+  }
+
   function resolveDockerImage(runsOn: string | string[] | undefined): string | undefined {
     if (values.local) return undefined;
     if (values.image) return values.image;
     const label = Array.isArray(runsOn) ? runsOn[0] : runsOn;
     const key = label || "ubuntu-latest";
-    return platformOverrides[key] || DEFAULT_IMAGES[key] || DEFAULT_IMAGES["ubuntu-latest"];
+    return platformOverrides[key] || resolveRunsOnImage(key) || DEFAULT_IMAGES["ubuntu-latest"];
   }
 
   let anyFailed = false;


### PR DESCRIPTION
## Summary
- Adds `resolveRunsOnImage()` to map larger runner variants (e.g. `ubuntu-latest-4-cores`, `ubuntu-24.04-16-cores`) to the correct Docker image by stripping resource suffixes and using prefix matching
- Unknown labels still fall back to `ubuntu-latest` (ubuntu24 image)

Closes #25

## Test plan
- [x] All 87 existing unit tests pass
- [ ] Test with workflow using `ubuntu-22.04` → should use `ubuntu22` image
- [ ] Test with workflow using `ubuntu-latest-4-cores` → should use `ubuntu24` image

🤖 Generated with [Claude Code](https://claude.com/claude-code)