### PR TITLE
Add --matrix flag for matrix strategy filtering

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -11,6 +11,7 @@ import { resolveSecrets, scanRequiredSecrets } from "./secrets";
 import { resolveVariables } from "./variables";
 import { existsSync } from "fs";
 import { OutputHandler, type OutputMode } from "./output";
+import { expandMatrix, filterMatrix, formatMatrixCombo } from "./matrix";
 
 const { values, positionals } = parseArgs({
   args: Bun.argv.slice(2),
@@ -29,6 +30,7 @@ const { values, positionals } = parseArgs({
     port: { type: "string", default: "9637" },
     raw: { type: "boolean" },
     verbose: { type: "boolean", short: "v" },
+    matrix: { type: "string", short: "m", multiple: true },
     "list-events": { type: "boolean" },
     help: { type: "boolean", short: "h" },
   },
@@ -63,6 +65,7 @@ Flags:
   --local                    Run with local runner instead of Docker (default: Docker)
   --image <name>             Docker image override for all jobs
   -P, --platform <label=img> Map runs-on label to Docker image (e.g. -P ubuntu-latest=myimage:tag)
+  -m, --matrix <key:value>   Filter matrix combinations (e.g. --matrix node:18)
   --port <number>            Server port (default: 9637)
   --raw                      Raw output for agents (step markers + log lines)
   -v, --verbose              Verbose output with full server internals
@@ -75,7 +78,8 @@ Examples:
   localrunner -l                                 # list all workflows
   localrunner push -l                            # list push workflows
   localrunner push -W .github/workflows/ci.yml   # specific workflow
-  localrunner push -s MY_SECRET=foo              # with secret`);
+  localrunner push -s MY_SECRET=foo              # with secret
+  localrunner push --matrix node:18              # filter matrix`);
 }
 
 if (values.help && positionals[0]) {
@@ -343,12 +347,26 @@ async function main() {
 
     const selectedJob = workflow.jobs[selectedJobName]!;
     const dockerImage = resolveDockerImage(selectedJob["runs-on"]);
-    console.log(`Job: ${selectedJobName}${dockerImage ? ` (${selectedJob["runs-on"] || "ubuntu-latest"} → ${dockerImage})` : " (local)"}`);
 
     if (!selectedJob.steps || selectedJob.steps.length === 0) {
       console.error(`Error: job '${selectedJobName}' has no steps`);
       continue;
     }
+
+    // Expand matrix combinations
+    const matrixConfig = selectedJob.strategy?.matrix;
+    let matrixCombinations = expandMatrix(matrixConfig);
+    if (values.matrix && values.matrix.length > 0) {
+      matrixCombinations = filterMatrix(matrixCombinations, values.matrix);
+      if (matrixCombinations.length === 0) {
+        console.error(`Error: no matrix combinations match the provided --matrix filters`);
+        continue;
+      }
+    }
+
+    const hasMatrix = matrixCombinations.length > 0;
+    // If no matrix, run once with empty combo
+    const combosToRun = hasMatrix ? matrixCombinations : [{}];
 
     // Resolve secrets per-workflow (yaml scanning is workflow-specific)
     const secrets = await resolveSecrets({
@@ -375,43 +393,59 @@ async function main() {
 
     const eventPayload = await generateEventPayload(eventName, repoCtx, payloadOverrides, inputDefaults);
 
-    // Build expression context and convert steps
-    const exprCtx = buildExpressionContext(repoCtx, eventName, eventPayload, workflowName, selectedJobName, undefined, secrets, variables);
-
-    const jobSteps = workflowStepsToRunnerSteps(
-      selectedJob.steps,
-      (script, displayName) => scriptStep(evaluateExpressions(script, exprCtx), displayName),
-      (action, ref, displayName, inputs) => {
-        const evaluated = inputs
-          ? Object.fromEntries(Object.entries(inputs).map(([k, v]) => [k, evaluateExpressions(v, exprCtx)]))
-          : undefined;
-        return actionStep(action, ref, displayName, evaluated);
-      },
-    );
-    const serviceNames = selectedJob.services ? Object.keys(selectedJob.services) : [];
-    if (serviceNames.length > 0) {
-      console.log(`Services: ${serviceNames.join(", ")}`);
+    if (hasMatrix) {
+      console.log(`Job: ${selectedJobName} (${combosToRun.length} matrix combination${combosToRun.length > 1 ? "s" : ""})${dockerImage ? ` (${selectedJob["runs-on"] || "ubuntu-latest"} → ${dockerImage})` : " (local)"}`);
+    } else {
+      console.log(`Job: ${selectedJobName}${dockerImage ? ` (${selectedJob["runs-on"] || "ubuntu-latest"} → ${dockerImage})` : " (local)"}`);
     }
-    console.log(`Steps: ${jobSteps.length}\n`);
 
-    const result = await startRun({
-      port,
-      repoCtx,
-      jobSteps,
-      eventName,
-      eventPayload,
-      workflowName,
-      jobName: selectedJobName,
-      runnerDir,
-      secrets,
-      variables,
-      dockerImage,
-      services: selectedJob.services,
-      output,
-    });
+    for (const matrixCombo of combosToRun) {
+      const comboLabel = hasMatrix ? ` ${formatMatrixCombo(matrixCombo)}` : "";
+      if (hasMatrix) {
+        console.log(`\n  Matrix:${comboLabel}`);
+      }
 
-    if (result.conclusion !== "succeeded") {
-      anyFailed = true;
+      // Build expression context and convert steps
+      const exprCtx = buildExpressionContext(repoCtx, eventName, eventPayload, workflowName, selectedJobName, undefined, secrets, variables, hasMatrix ? matrixCombo : undefined);
+
+      const jobSteps = workflowStepsToRunnerSteps(
+        selectedJob.steps,
+        (script, displayName) => scriptStep(evaluateExpressions(script, exprCtx), displayName),
+        (action, ref, displayName, inputs) => {
+          const evaluated = inputs
+            ? Object.fromEntries(Object.entries(inputs).map(([k, v]) => [k, evaluateExpressions(v, exprCtx)]))
+            : undefined;
+          return actionStep(action, ref, displayName, evaluated);
+        },
+      );
+      const serviceNames = selectedJob.services ? Object.keys(selectedJob.services) : [];
+      if (serviceNames.length > 0) {
+        console.log(`Services: ${serviceNames.join(", ")}`);
+      }
+      console.log(`  Steps: ${jobSteps.length}\n`);
+
+      const jobDisplayName = hasMatrix ? `${selectedJobName}${comboLabel}` : selectedJobName;
+
+      const result = await startRun({
+        port,
+        repoCtx,
+        jobSteps,
+        eventName,
+        eventPayload,
+        workflowName,
+        jobName: jobDisplayName,
+        runnerDir,
+        secrets,
+        variables,
+        matrix: hasMatrix ? matrixCombo : undefined,
+        dockerImage,
+        services: selectedJob.services,
+        output,
+      });
+
+      if (result.conclusion !== "succeeded") {
+        anyFailed = true;
+      }
     }
 
     console.log();

--- a/expressions.ts
+++ b/expressions.ts
@@ -10,6 +10,7 @@ export function buildExpressionContext(
   stepEnv?: Record<string, string>,
   secrets?: Record<string, string>,
   variables?: Record<string, string>,
+  matrix?: Record<string, string>,
 ): Record<string, string> {
   const ctx: Record<string, string> = {};
 
@@ -81,6 +82,13 @@ export function buildExpressionContext(
   if (variables) {
     for (const [k, v] of Object.entries(variables)) {
       ctx[`vars.${k}`] = v;
+    }
+  }
+
+  // matrix context
+  if (matrix) {
+    for (const [k, v] of Object.entries(matrix)) {
+      ctx[`matrix.${k}`] = v;
     }
   }
 

--- a/matrix.test.ts
+++ b/matrix.test.ts
@@ -1,0 +1,132 @@
+import { test, expect, describe } from "bun:test";
+import { expandMatrix, filterMatrix, formatMatrixCombo } from "./matrix";
+
+describe("expandMatrix", () => {
+  test("returns empty array for undefined/null", () => {
+    expect(expandMatrix(undefined)).toEqual([]);
+    expect(expandMatrix(null)).toEqual([]);
+  });
+
+  test("expands single dimension", () => {
+    const result = expandMatrix({ os: ["ubuntu", "macos"] });
+    expect(result).toEqual([
+      { os: "ubuntu" },
+      { os: "macos" },
+    ]);
+  });
+
+  test("expands cartesian product of multiple dimensions", () => {
+    const result = expandMatrix({
+      os: ["ubuntu", "macos"],
+      node: [16, 18],
+    });
+    expect(result).toEqual([
+      { os: "ubuntu", node: "16" },
+      { os: "ubuntu", node: "18" },
+      { os: "macos", node: "16" },
+      { os: "macos", node: "18" },
+    ]);
+  });
+
+  test("applies exclude to remove matching combinations", () => {
+    const result = expandMatrix({
+      os: ["ubuntu", "macos"],
+      node: [16, 18],
+      exclude: [{ os: "macos", node: 16 }],
+    });
+    expect(result).toEqual([
+      { os: "ubuntu", node: "16" },
+      { os: "ubuntu", node: "18" },
+      { os: "macos", node: "18" },
+    ]);
+  });
+
+  test("applies include to augment existing combinations", () => {
+    const result = expandMatrix({
+      os: ["ubuntu"],
+      node: [16, 18],
+      include: [{ os: "ubuntu", node: "16", experimental: "true" }],
+    });
+    expect(result).toEqual([
+      { os: "ubuntu", node: "16", experimental: "true" },
+      { os: "ubuntu", node: "18" },
+    ]);
+  });
+
+  test("applies include to add new standalone combinations", () => {
+    const result = expandMatrix({
+      os: ["ubuntu"],
+      include: [{ os: "windows", special: "yes" }],
+    });
+    expect(result).toEqual([
+      { os: "ubuntu" },
+      { os: "windows", special: "yes" },
+    ]);
+  });
+
+  test("include-only matrix (no dimensions)", () => {
+    const result = expandMatrix({
+      include: [
+        { os: "ubuntu", version: "2204" },
+        { os: "ubuntu", version: "2404" },
+      ],
+    });
+    expect(result).toEqual([
+      { os: "ubuntu", version: "2204" },
+      { os: "ubuntu", version: "2404" },
+    ]);
+  });
+
+  test("stringifies numeric values", () => {
+    const result = expandMatrix({ shard: [0, 1, 2] });
+    expect(result).toEqual([
+      { shard: "0" },
+      { shard: "1" },
+      { shard: "2" },
+    ]);
+  });
+});
+
+describe("filterMatrix", () => {
+  const combos = [
+    { os: "ubuntu", node: "16" },
+    { os: "ubuntu", node: "18" },
+    { os: "macos", node: "16" },
+    { os: "macos", node: "18" },
+  ];
+
+  test("returns all combinations when no filters", () => {
+    expect(filterMatrix(combos, [])).toEqual(combos);
+  });
+
+  test("filters by single key:value", () => {
+    expect(filterMatrix(combos, ["node:18"])).toEqual([
+      { os: "ubuntu", node: "18" },
+      { os: "macos", node: "18" },
+    ]);
+  });
+
+  test("filters by multiple key:value pairs (AND)", () => {
+    expect(filterMatrix(combos, ["node:18", "os:ubuntu"])).toEqual([
+      { os: "ubuntu", node: "18" },
+    ]);
+  });
+
+  test("returns empty when no matches", () => {
+    expect(filterMatrix(combos, ["node:20"])).toEqual([]);
+  });
+
+  test("throws on invalid filter format", () => {
+    expect(() => filterMatrix(combos, ["invalid"])).toThrow("Invalid --matrix filter");
+  });
+});
+
+describe("formatMatrixCombo", () => {
+  test("formats single key", () => {
+    expect(formatMatrixCombo({ node: "18" })).toBe("(node: 18)");
+  });
+
+  test("formats multiple keys", () => {
+    expect(formatMatrixCombo({ os: "ubuntu", node: "18" })).toBe("(os: ubuntu, node: 18)");
+  });
+});

--- a/matrix.ts
+++ b/matrix.ts
@@ -1,0 +1,130 @@
+/**
+ * Matrix strategy expansion and filtering for GitHub Actions workflows.
+ *
+ * Supports:
+ * - Simple key→array definitions (Cartesian product)
+ * - `include` entries (add or augment combinations)
+ * - `exclude` entries (remove matching combinations)
+ * - CLI `--matrix key:value` filtering
+ */
+
+export type MatrixCombination = Record<string, string>;
+
+export interface MatrixConfig {
+  include?: MatrixCombination[];
+  exclude?: MatrixCombination[];
+  [key: string]: unknown;
+}
+
+/**
+ * Expand a strategy.matrix config into an array of combinations.
+ */
+export function expandMatrix(matrix: MatrixConfig | undefined | null): MatrixCombination[] {
+  if (!matrix || typeof matrix !== "object") return [];
+
+  const { include, exclude, ...dimensions } = matrix;
+
+  // Build Cartesian product of all dimension arrays
+  const dimEntries = Object.entries(dimensions).filter(
+    ([, v]) => Array.isArray(v),
+  ) as [string, unknown[]][];
+
+  let combinations: MatrixCombination[] = [];
+
+  if (dimEntries.length > 0) {
+    combinations = cartesian(dimEntries);
+  }
+
+  // Apply exclude: remove combinations that match all keys in an exclude entry
+  if (Array.isArray(exclude)) {
+    combinations = combinations.filter(
+      (combo) => !exclude.some((ex) => matchesCombination(combo, ex)),
+    );
+  }
+
+  // Apply include: add new combinations or augment existing ones
+  if (Array.isArray(include)) {
+    for (const inc of include) {
+      // Check if this include entry matches an existing combination on the
+      // dimension keys. If so, merge extra keys into that combination.
+      // Otherwise, add it as a new standalone combination.
+      const dimKeys = dimEntries.map(([k]) => k);
+      const matchesDimensions = dimKeys.length > 0 && dimKeys.every((k) => k in inc);
+
+      if (matchesDimensions) {
+        let matched = false;
+        for (const combo of combinations) {
+          if (dimKeys.every((k) => String(combo[k]) === String(inc[k]))) {
+            Object.assign(combo, stringifyValues(inc));
+            matched = true;
+          }
+        }
+        if (!matched) {
+          combinations.push(stringifyValues(inc));
+        }
+      } else {
+        combinations.push(stringifyValues(inc));
+      }
+    }
+  }
+
+  return combinations;
+}
+
+/**
+ * Filter matrix combinations by `--matrix key:value` CLI args.
+ */
+export function filterMatrix(
+  combinations: MatrixCombination[],
+  filters: string[],
+): MatrixCombination[] {
+  if (filters.length === 0) return combinations;
+
+  const parsed = filters.map((f) => {
+    const colon = f.indexOf(":");
+    if (colon === -1) {
+      throw new Error(`Invalid --matrix filter '${f}', expected key:value format`);
+    }
+    return { key: f.slice(0, colon), value: f.slice(colon + 1) };
+  });
+
+  return combinations.filter((combo) =>
+    parsed.every(({ key, value }) => combo[key] === value),
+  );
+}
+
+/**
+ * Format a matrix combination for display, e.g. "(node: 18, os: ubuntu-latest)"
+ */
+export function formatMatrixCombo(combo: MatrixCombination): string {
+  const parts = Object.entries(combo).map(([k, v]) => `${k}: ${v}`);
+  return `(${parts.join(", ")})`;
+}
+
+function cartesian(dims: [string, unknown[]][]): MatrixCombination[] {
+  if (dims.length === 0) return [{}];
+
+  const [first, ...rest] = dims;
+  const [key, values] = first!;
+  const restCombos = cartesian(rest);
+
+  const result: MatrixCombination[] = [];
+  for (const val of values) {
+    for (const combo of restCombos) {
+      result.push({ [key]: String(val), ...combo });
+    }
+  }
+  return result;
+}
+
+function matchesCombination(combo: MatrixCombination, pattern: MatrixCombination): boolean {
+  return Object.entries(pattern).every(
+    ([k, v]) => String(combo[k]) === String(v),
+  );
+}
+
+function stringifyValues(obj: Record<string, unknown>): MatrixCombination {
+  return Object.fromEntries(
+    Object.entries(obj).map(([k, v]) => [k, String(v)]),
+  );
+}

--- a/orchestrator.ts
+++ b/orchestrator.ts
@@ -15,6 +15,7 @@ export interface RunConfig {
   runnerDir: string;
   secrets?: Record<string, string>;
   variables?: Record<string, string>;
+  matrix?: Record<string, string>;
   dockerImage?: string;
   services?: Record<string, Service>;
   output?: OutputHandler;
@@ -55,7 +56,7 @@ export interface RunResult {
 }
 
 export async function startRun(config: RunConfig): Promise<RunResult> {
-  const { port, repoCtx, jobSteps, eventName, eventPayload, workflowName, jobName, runnerDir, secrets, variables, dockerImage, services, output: configOutput } = config;
+  const { port, repoCtx, jobSteps, eventName, eventPayload, workflowName, jobName, runnerDir, secrets, variables, matrix, dockerImage, services, output: configOutput } = config;
 
   const isDocker = !!dockerImage;
   const hostAddress = isDocker ? "host.docker.internal" : "localhost";
@@ -75,6 +76,7 @@ export async function startRun(config: RunConfig): Promise<RunResult> {
     jobName,
     secrets,
     variables,
+    matrix,
     hostAddress,
     runnerOs: isDocker ? "Linux" : "macOS",
     runnerArch: isDocker ? "X64" : "ARM64",

--- a/server/job.ts
+++ b/server/job.ts
@@ -113,7 +113,10 @@ function buildJobMessage(ctx: RunContext): object {
     contextData: {
       github: buildGitHubContextData(ctx.repoCtx, ctx.eventName, ctx.eventPayload, ctx.workflowName, ctx.jobName, ctx.runId),
       strategy: { t: 2, d: [] },
-      matrix: { t: 2, d: [] },
+      matrix: {
+        t: 2,
+        d: Object.entries(ctx.matrix).map(([k, v]) => ({ k, v })),
+      },
       job: { t: 2, d: [] },
       runner: {
         t: 2,

--- a/server/types.ts
+++ b/server/types.ts
@@ -13,6 +13,7 @@ export interface ServerConfig {
   secrets?: Record<string, string>;
   variables?: Record<string, string>;
   hostAddress?: string;
+  matrix?: Record<string, string>;
   runnerOs?: string;
   runnerArch?: string;
   output?: OutputHandler;
@@ -34,6 +35,7 @@ export interface RunContext {
   jobName: string;
   secrets: Record<string, string>;
   variables: Record<string, string>;
+  matrix: Record<string, string>;
   hostAddress: string;
   serverBaseUrl: string;
   runnerOs: string;
@@ -76,6 +78,7 @@ export function createRunContext(config: ServerConfig): { ctx: RunContext; jobCo
     jobName: config.jobName,
     secrets: config.secrets || {},
     variables: config.variables || {},
+    matrix: config.matrix || {},
     hostAddress,
     serverBaseUrl,
     runnerOs: config.runnerOs || "macOS",


### PR DESCRIPTION
## Summary
- Adds matrix strategy expansion: jobs with `strategy.matrix` now run all combinations (Cartesian product, `include`, `exclude`)
- Adds `--matrix` / `-m` CLI flag to filter which combinations to run (e.g. `--matrix node:18 --matrix os:ubuntu`)
- Wires `matrix.*` context through expression evaluation and the runner protocol so `${{ matrix.node }}` resolves correctly

Closes #14

## Test plan
- [x] 15 unit tests for `expandMatrix`, `filterMatrix`, and `formatMatrixCombo`
- [x] All 106 existing tests still pass
- [x] End-to-end: ran a 2×2 matrix workflow (node×os), verified all 4 combinations execute
- [x] End-to-end: `--matrix node:18 --matrix os:ubuntu` correctly filters to 1 combination

🤖 Generated with [Claude Code](https://claude.com/claude-code)