### PR TITLE
Add bunfig.toml test profiles for unit and acceptance tests

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Pull localrunner image
         run: docker pull ghcr.io/camdenclark/localrunner:ubuntu24
       - name: Run acceptance tests (shard ${{ matrix.shard }})
-        run: bun test acceptance/
+        run: bun test --config=acceptance
         env:
           SHARD_INDEX: ${{ matrix.shard }}
           SHARD_TOTAL: 3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Install dependencies
         run: bun install
       - name: Run unit tests
-        run: bun test ./*.test.ts
+        run: bun test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Commands
 
-- `bun test` — run all unit tests
+- `bun test` — run unit tests (default profile)
+- `bun test --config=acceptance` — run acceptance tests
 - `bun test <file>` — run a single test file (e.g. `bun test expressions.test.ts`)
 - `bun cli.ts push` — run workflows matching a `push` event
 - `bun cli.ts pull_request` — run workflows matching a `pull_request` event
@@ -61,7 +62,9 @@ Three modes: **pretty** (colored, human-friendly, default), **raw** (minimal mar
 
 ## Testing
 
-- Unit tests live alongside source files (`*.test.ts` in root)
-- Acceptance tests in `acceptance/` clone real repos and run localrunner end-to-end
-- `bunfig.toml` excludes `runner/**` from test discovery
-- Acceptance tests support sharding via `SHARD_INDEX`/`SHARD_TOTAL` env vars
+There are two test profiles configured in `bunfig.toml`:
+
+- **`bun test`** — runs **unit tests** only (`*.test.ts` in project root). This is the default profile and what you should run after making code changes.
+- **`bun test --config=acceptance`** — runs **acceptance tests** (`acceptance/`). These clone real repos and run localrunner end-to-end. Only run these when specifically asked or when testing end-to-end behavior.
+
+Unit tests live alongside source files in the project root. Acceptance tests live in `acceptance/` and support sharding via `SHARD_INDEX`/`SHARD_TOTAL` env vars.

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,2 +1,9 @@
 [test]
+# Default: unit tests only (excludes runner/ and acceptance/)
+pathIgnorePatterns = ["runner/**", "acceptance/**"]
+
+[test.acceptance]
+# Acceptance tests: end-to-end tests in acceptance/
+root = "acceptance"
 pathIgnorePatterns = ["runner/**"]
+timeout = 300000


### PR DESCRIPTION
## Summary
- Configure two test profiles in `bunfig.toml`: default (unit tests) and `acceptance`
- `bun test` now runs only unit tests; `bun test --config=acceptance` runs acceptance tests
- Update CI workflows to use the profiles instead of hardcoded paths
- Update CLAUDE.md to document both profiles clearly

## Test plan
- [x] `bun test` runs 87 unit tests, excludes acceptance tests
- [ ] `bun test --config=acceptance` runs acceptance tests from `acceptance/` root

🤖 Generated with [Claude Code](https://claude.com/claude-code)