### PR TITLE
Fix acceptance test config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Commands
 
 - `bun test` — run unit tests (default profile)
-- `bun test --config=acceptance` — run acceptance tests
+- `bun test --config=bunfig.acceptance.toml` — run acceptance tests
 - `bun test <file>` — run a single test file (e.g. `bun test expressions.test.ts`)
 - `bun cli.ts push` — run workflows matching a `push` event
 - `bun cli.ts pull_request` — run workflows matching a `pull_request` event

--- a/bunfig.acceptance.toml
+++ b/bunfig.acceptance.toml
@@ -1,0 +1,5 @@
+[test]
+# Acceptance tests: end-to-end tests in acceptance/
+root = "acceptance"
+pathIgnorePatterns = ["runner/**"]
+timeout = 300000

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,9 +1,3 @@
 [test]
 # Default: unit tests only (excludes runner/ and acceptance/)
 pathIgnorePatterns = ["runner/**", "acceptance/**"]
-
-[test.acceptance]
-# Acceptance tests: end-to-end tests in acceptance/
-root = "acceptance"
-pathIgnorePatterns = ["runner/**"]
-timeout = 300000


### PR DESCRIPTION
## Summary
- bun's `--config` flag takes a file path, not a section name — `[test.acceptance]` in bunfig.toml was never working
- Moved acceptance test config to a separate `bunfig.acceptance.toml` file
- Updated CLAUDE.md to use `bun test --config=bunfig.acceptance.toml`

## Test plan
- [x] `bun test` runs unit tests only
- [x] `bun test --config=bunfig.acceptance.toml` finds and runs acceptance tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)