### PR TITLE
Add Hono web UI and long-lived server mode

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "localrunner",
       "dependencies": {
         "drizzle-orm": "^0.45.1",
+        "hono": "^4.12.9",
         "zod": "^3.25.0-beta.20250519T094321",
       },
       "devDependencies": {
@@ -93,6 +94,8 @@
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "get-tsconfig": ["get-tsconfig@4.13.7", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q=="],
+
+    "hono": ["hono@4.12.9", "", {}, "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 

--- a/cli.ts
+++ b/cli.ts
@@ -5,7 +5,7 @@ import { getRepoContext } from "./context";
 import { parseWorkflow, matchesEvent, normalizeOn, workflowStepsToRunnerSteps } from "./workflow";
 import { generateEventPayload, EVENT_DEFINITIONS, EVENT_REGISTRY } from "./events";
 import { scriptStep, actionStep } from "./server/index";
-import { startRun } from "./orchestrator";
+import { startRun, startRunOnRemoteServer } from "./orchestrator";
 import { buildExpressionContext, evaluateExpressions } from "./expressions";
 import { resolveSecrets, scanRequiredSecrets } from "./secrets";
 import { resolveVariables } from "./variables";
@@ -47,11 +47,15 @@ function printUsage() {
     .join("\n");
 
   console.log(`Usage: localrunner [event] [flags]
+       localrunner serve [--port 9637]
 
 Events:
 ${eventLines}
 
   Use --list-events to see all ${EVENT_REGISTRY.size} supported events.
+
+Commands:
+  serve                     Start the long-lived server with web UI
 
 Flags:
   -W, --workflows <path>    Workflow file or directory (default: .github/workflows/)
@@ -168,6 +172,45 @@ if (values["list-events"]) {
   process.exit(0);
 }
 
+// --- Serve subcommand ---
+if (positionals[0] === "serve") {
+  const port = parseInt(values.port || "9637", 10);
+  const { createMultiRunApp, websocket } = await import("./server/hono");
+  const { RunManager } = await import("./server/runs");
+  const { registerWebRoutes } = await import("./web/routes");
+  const { registerApiRoutes } = await import("./web/api");
+
+  const runManager = new RunManager();
+  const { app, addRunnerCatchAll } = createMultiRunApp(runManager);
+
+  registerWebRoutes(app);
+  registerApiRoutes(app, runManager, port);
+  addRunnerCatchAll();
+
+  const server = Bun.serve({ port, fetch: app.fetch, websocket });
+
+  console.log(`localrunner server listening on http://localhost:${port}`);
+  console.log(`Web UI: http://localhost:${port}/`);
+  console.log(`Press Ctrl+C to stop.\n`);
+
+  const pidFile = `${process.env.HOME}/.localrunner/server.pid`;
+  await Bun.write(pidFile, String(process.pid));
+
+  process.on("SIGINT", () => {
+    try { require("fs").unlinkSync(pidFile); } catch {}
+    server.stop(true);
+    process.exit(0);
+  });
+  process.on("SIGTERM", () => {
+    try { require("fs").unlinkSync(pidFile); } catch {}
+    server.stop(true);
+    process.exit(0);
+  });
+
+  // Keep the process alive
+  await new Promise(() => {});
+}
+
 // Event name: first positional or default to "push"
 const eventName: string = positionals[0] || "push";
 
@@ -180,6 +223,17 @@ const port = parseInt(values.port || "9637", 10);
 
 const outputMode: OutputMode = values.raw ? "raw" : values.verbose ? "verbose" : "pretty";
 const output = new OutputHandler(outputMode);
+
+/** Check if the long-lived server is running on the given port. */
+async function isServerRunning(): Promise<boolean> {
+  try {
+    const res = await fetch(`http://localhost:${port}/api/health`, { signal: AbortSignal.timeout(500) });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
 
 // --- Find and parse workflow(s) ---
 
@@ -241,7 +295,12 @@ async function main() {
     return process.exit(0);
   }
 
+  const serverRunning = await isServerRunning();
+
   console.log("=== localrunner ===\n");
+  if (serverRunning) {
+    console.log(`Using running server on port ${port}\n`);
+  }
 
   // --- Find workflows ---
   let workflowMatches: { path: string; workflow: ReturnType<typeof parseWorkflow>; yamlText: string }[];
@@ -447,22 +506,43 @@ async function main() {
 
       const jobDisplayName = hasMatrix ? `${selectedJobName}${comboLabel}` : selectedJobName;
 
-      const result = await startRun({
-        port,
-        repoCtx,
-        jobSteps,
-        eventName,
-        eventPayload,
-        workflowName,
-        jobName: jobDisplayName,
-        runnerDir,
-        secrets,
-        variables,
-        matrix: hasMatrix ? matrixCombo : undefined,
-        dockerImage,
-        services: selectedJob.services,
-        output,
-      });
+      let result: { conclusion: string };
+
+      if (serverRunning) {
+        result = await startRunOnRemoteServer({
+          port,
+          repoCtx,
+          jobSteps,
+          eventName,
+          eventPayload,
+          workflowName,
+          jobName: jobDisplayName,
+          runnerDir,
+          secrets,
+          variables,
+          matrix: hasMatrix ? matrixCombo : undefined,
+          dockerImage,
+          services: selectedJob.services,
+          output,
+        });
+      } else {
+        result = await startRun({
+          port,
+          repoCtx,
+          jobSteps,
+          eventName,
+          eventPayload,
+          workflowName,
+          jobName: jobDisplayName,
+          runnerDir,
+          secrets,
+          variables,
+          matrix: hasMatrix ? matrixCombo : undefined,
+          dockerImage,
+          services: selectedJob.services,
+          output,
+        });
+      }
 
       if (result.conclusion !== "succeeded") {
         anyFailed = true;

--- a/orchestrator.ts
+++ b/orchestrator.ts
@@ -3,6 +3,8 @@ import { tmpdir } from "os";
 import { join } from "path";
 import type { Service } from "./workflow";
 import { OutputHandler } from "./output";
+import type { RunContext } from "./server/types";
+import type { RunManager } from "./server/runs";
 
 export interface RunConfig {
   port: number;
@@ -55,33 +57,30 @@ export interface RunResult {
   logs: string[];
 }
 
-export async function startRun(config: RunConfig): Promise<RunResult> {
-  const { port, repoCtx, jobSteps, eventName, eventPayload, workflowName, jobName, runnerDir, secrets, variables, matrix, dockerImage, services, output: configOutput } = config;
-
+/**
+ * Launch a runner process and wait for job completion.
+ * Shared between ephemeral server mode (startRun) and long-lived server mode (startRunOnServer).
+ */
+export async function launchRunner(opts: {
+  port: number;
+  hostAddress: string;
+  dockerImage?: string;
+  runnerDir: string;
+  eventPayload: object;
+  services?: Record<string, Service>;
+  output: OutputHandler;
+  jobCompleted: Promise<string>;
+  /** If provided, cleanup won't stop the server */
+  stopServer?: () => void;
+  /** Called when the run finishes */
+  onComplete?: () => void;
+}): Promise<RunResult> {
+  const { port, hostAddress, dockerImage, runnerDir, eventPayload, services, output, jobCompleted, stopServer, onComplete } = opts;
   const isDocker = !!dockerImage;
-  const hostAddress = isDocker ? "host.docker.internal" : "localhost";
 
   // Write event.json to a temp directory for the runner
   const tmpDir = join(tmpdir(), `localrunner-${Date.now()}`);
   await Bun.write(join(tmpDir, "event.json"), JSON.stringify(eventPayload, null, 2));
-
-  // Start the mock server
-  const { server, jobCompleted, output } = createServer({
-    port,
-    repoCtx,
-    jobSteps,
-    eventName,
-    eventPayload,
-    workflowName,
-    jobName,
-    secrets,
-    variables,
-    matrix,
-    hostAddress,
-    runnerOs: isDocker ? "Linux" : "macOS",
-    runnerArch: isDocker ? "X64" : "ARM64",
-    output: configOutput,
-  });
 
   const jitconfig = buildJitConfig(port, hostAddress);
 
@@ -92,7 +91,7 @@ export async function startRun(config: RunConfig): Promise<RunResult> {
     const netProc = Bun.spawnSync(["docker", "network", "create", networkName]);
     if (netProc.exitCode !== 0) {
       output.emit({ type: "info", message: `Failed to create Docker network: ${netProc.stderr.toString()}` });
-      server.stop(true);
+      stopServer?.();
       process.exit(1);
     }
   }
@@ -109,28 +108,24 @@ export async function startRun(config: RunConfig): Promise<RunResult> {
         "--name", `${networkName}-${serviceName}`,
       ];
 
-      // Add environment variables
       if (serviceConfig.env) {
         for (const [key, value] of Object.entries(serviceConfig.env)) {
           args.push("-e", `${key}=${value}`);
         }
       }
 
-      // Add port mappings
       if (serviceConfig.ports) {
-        for (const port of serviceConfig.ports) {
-          args.push("-p", String(port));
+        for (const p of serviceConfig.ports) {
+          args.push("-p", String(p));
         }
       }
 
-      // Add volume mounts
       if (serviceConfig.volumes) {
         for (const vol of serviceConfig.volumes) {
           args.push("-v", vol);
         }
       }
 
-      // Add extra docker options (respecting quoted strings)
       if (serviceConfig.options) {
         const optionTokens: string[] = [];
         const regex = /"([^"]*)"|\S+/g;
@@ -146,23 +141,19 @@ export async function startRun(config: RunConfig): Promise<RunResult> {
       const svcProc = Bun.spawnSync(args);
       if (svcProc.exitCode !== 0) {
         output.emit({ type: "info", message: `Failed to start service '${serviceName}': ${svcProc.stderr.toString()}` });
-        // Clean up any already-started services
         for (const id of serviceContainerIds) {
           Bun.spawnSync(["docker", "rm", "-f", id]);
         }
         if (networkName) Bun.spawnSync(["docker", "network", "rm", networkName]);
-        server.stop(true);
+        stopServer?.();
         process.exit(1);
       }
       const containerId = svcProc.stdout.toString().trim();
       serviceContainerIds.push(containerId);
     }
-
-    // Wait briefly for services to initialize
     await new Promise((r) => setTimeout(r, 2000));
   }
 
-  // Cleanup function to kill containers, remove networks, stop server, and clean temp files
   let proc: ReturnType<typeof Bun.spawn> | undefined;
   let runnerContainerName: string | undefined;
   let cleanedUp = false;
@@ -189,15 +180,15 @@ export async function startRun(config: RunConfig): Promise<RunResult> {
       Bun.spawnSync(["docker", "network", "rm", networkName]);
     }
 
-    server.stop(true);
+    stopServer?.();
 
     try {
       const fs = require("fs");
       fs.unlinkSync(join(tmpDir, "event.json"));
       fs.rmdirSync(tmpDir);
-    } catch {
-      // best effort cleanup
-    }
+    } catch {}
+
+    onComplete?.();
   }
 
   function onSignal() {
@@ -242,7 +233,6 @@ export async function startRun(config: RunConfig): Promise<RunResult> {
     });
   }
 
-  // Stream runner output and emit via output handler
   async function pipeStream(stream: ReadableStream<Uint8Array> | null, streamName: "stdout" | "stderr") {
     if (!stream) return;
     const reader = stream.getReader();
@@ -266,7 +256,6 @@ export async function startRun(config: RunConfig): Promise<RunResult> {
   const stdoutPipe = pipeStream(proc!.stdout as ReadableStream<Uint8Array>, "stdout");
   const stderrPipe = pipeStream(proc!.stderr as ReadableStream<Uint8Array>, "stderr");
 
-  // Wait for either job completion or runner exit
   const runnerExit = proc!.exited;
 
   const conclusion = await Promise.race([
@@ -274,25 +263,203 @@ export async function startRun(config: RunConfig): Promise<RunResult> {
     runnerExit.then(() => "failed" as string),
   ]);
 
-  // Wait for output streams to finish
   await Promise.allSettled([stdoutPipe, stderrPipe]);
-
-  // Give a moment for final logs to flush
   await new Promise((r) => setTimeout(r, 500));
 
-  // If the job wasn't completed via the server (e.g. runner crashed or was killed),
-  // mark the run as cancelled in the DB
   if (!output.jobCompleted) {
     output.markCancelled();
   }
 
-  // Clean up
-  output.emit({ type: "info", message: "\nRunner finished. Stopping server..." });
+  output.emit({ type: "info", message: "\nRunner finished." });
   cleanup();
 
-  // Remove signal handlers so they don't interfere with subsequent runs
   process.removeListener("SIGINT", onSignal);
   process.removeListener("SIGTERM", onSignal);
 
   return { conclusion, logs: output.allLogs };
+}
+
+/**
+ * Start a run with an ephemeral server (original CLI flow).
+ * Creates a server, runs the job, stops the server when done.
+ */
+export async function startRun(config: RunConfig): Promise<RunResult> {
+  const { port, repoCtx, jobSteps, eventName, eventPayload, workflowName, jobName, runnerDir, secrets, variables, matrix, dockerImage, services, output: configOutput } = config;
+
+  const isDocker = !!dockerImage;
+  const hostAddress = isDocker ? "host.docker.internal" : "localhost";
+
+  const { server, jobCompleted, output } = createServer({
+    port,
+    repoCtx,
+    jobSteps,
+    eventName,
+    eventPayload,
+    workflowName,
+    jobName,
+    secrets,
+    variables,
+    matrix,
+    hostAddress,
+    runnerOs: isDocker ? "Linux" : "macOS",
+    runnerArch: isDocker ? "X64" : "ARM64",
+    output: configOutput,
+  });
+
+  return launchRunner({
+    port,
+    hostAddress,
+    dockerImage,
+    runnerDir,
+    eventPayload,
+    services,
+    output,
+    jobCompleted,
+    stopServer: () => server.stop(true),
+  });
+}
+
+/**
+ * Start a run on the long-lived server (no server creation/teardown).
+ * Used by serve.ts when a run is triggered via the API.
+ */
+export async function startRunOnServer(opts: {
+  ctx: RunContext;
+  jobCompleted: Promise<string>;
+  runManager: RunManager;
+  runnerDir: string;
+  dockerImage?: string;
+  services?: Record<string, Service>;
+  output: OutputHandler;
+}): Promise<RunResult> {
+  const { ctx, jobCompleted, runManager, runnerDir, dockerImage, services, output } = opts;
+  const isDocker = !!dockerImage;
+  const hostAddress = isDocker ? "host.docker.internal" : "localhost";
+
+  return launchRunner({
+    port: ctx.port,
+    hostAddress,
+    dockerImage,
+    runnerDir,
+    eventPayload: ctx.eventPayload,
+    services,
+    output,
+    jobCompleted,
+    // Don't stop the server — it's long-lived
+    stopServer: undefined,
+    onComplete: () => runManager.completeRun(ctx.runId),
+  });
+}
+
+/**
+ * Start a run against a remote long-lived server.
+ * Used by the CLI when it detects an already-running server.
+ *
+ * 1. Registers the run on the server via HTTP
+ * 2. Connects to SSE for real-time output events
+ * 3. Launches the runner locally, pointing at the server
+ * 4. Waits for job completion (signaled via SSE)
+ */
+export async function startRunOnRemoteServer(config: RunConfig): Promise<RunResult> {
+  const { port, repoCtx, jobSteps, eventName, eventPayload, workflowName, jobName, runnerDir, secrets, variables, matrix, dockerImage, services, output: configOutput } = config;
+
+  const isDocker = !!dockerImage;
+  const hostAddress = isDocker ? "host.docker.internal" : "localhost";
+  const output = configOutput ?? new OutputHandler("verbose");
+
+  // 1. Register the run on the server
+  const res = await fetch(`http://localhost:${port}/api/register-run`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      config: {
+        repoCtx,
+        jobSteps,
+        eventName,
+        eventPayload,
+        workflowName,
+        jobName,
+        secrets,
+        variables,
+        matrix,
+        hostAddress,
+        runnerOs: isDocker ? "Linux" : "macOS",
+        runnerArch: isDocker ? "X64" : "ARM64",
+      },
+    }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to register run on server: ${await res.text()}`);
+  }
+
+  const { runId } = (await res.json()) as { runId: string };
+  output.emit({ type: "info", message: `Run registered on server (runId: ${runId})` });
+  output.emit({ type: "info", message: `View in browser: http://localhost:${port}/runs/${runId}\n` });
+
+  // 2. Connect to SSE for real-time output, and create a jobCompleted promise
+  let resolveJobCompleted!: (conclusion: string) => void;
+  const jobCompleted = new Promise<string>((resolve) => {
+    resolveJobCompleted = resolve;
+  });
+
+  // Connect to SSE — await the initial response so we know the stream is established
+  const abortController = new AbortController();
+  const sseRes = await fetch(`http://localhost:${port}/api/runs/${runId}/events`, {
+    signal: abortController.signal,
+  });
+
+  // Parse SSE frames in the background (don't await — stream is long-lived)
+  if (sseRes.body) {
+    const reader = sseRes.body.getReader();
+    const decoder = new TextDecoder();
+    (async () => {
+      let buffer = "";
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          const frames = buffer.split("\n\n");
+          buffer = frames.pop() || "";
+          for (const frame of frames) {
+            if (!frame.trim()) continue;
+            let eventType = "message";
+            let data = "";
+            for (const line of frame.split("\n")) {
+              if (line.startsWith("event: ")) eventType = line.slice(7).trim();
+              else if (line.startsWith("data: ")) data = line.slice(6);
+            }
+            if (!data || eventType === "keepalive") continue;
+            try {
+              const parsed = JSON.parse(data);
+              output.emit(parsed);
+              if (eventType === "job_complete") {
+                resolveJobCompleted(parsed.conclusion || "unknown");
+              }
+            } catch {}
+          }
+        }
+      } catch {
+        // Stream closed (abort or server disconnect)
+      }
+    })();
+  }
+
+  // 3. Launch runner locally, pointing at the already-running server
+  const result = await launchRunner({
+    port,
+    hostAddress,
+    dockerImage,
+    runnerDir,
+    eventPayload,
+    services,
+    output,
+    jobCompleted,
+    // Don't stop the server — it's long-lived
+    stopServer: undefined,
+  });
+
+  abortController.abort();
+  return result;
 }

--- a/output.ts
+++ b/output.ts
@@ -34,13 +34,26 @@ export class OutputHandler {
   private stepSortOrder = 0;
   private pendingLogs: Map<string, { stepId: number; lines: string[] }> = new Map();
 
+  /** External subscribers for event streaming (e.g. SSE) */
+  private subscribers: Set<(event: RunEvent) => void> = new Set();
+
   constructor(mode: OutputMode) {
     this.mode = mode;
+  }
+
+  subscribe(fn: (event: RunEvent) => void): () => void {
+    this.subscribers.add(fn);
+    return () => this.subscribers.delete(fn);
   }
 
   emit(event: RunEvent): void {
     if (event.type === "job_complete") {
       this.jobCompleted = true;
+    }
+
+    // Notify subscribers
+    for (const fn of this.subscribers) {
+      fn(event);
     }
     switch (this.mode) {
       case "verbose":

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "drizzle-orm": "^0.45.1",
+    "hono": "^4.12.9",
     "zod": "^3.25.0-beta.20250519T094321"
   }
 }

--- a/serve.ts
+++ b/serve.ts
@@ -1,0 +1,63 @@
+#!/usr/bin/env bun
+/**
+ * Long-lived localrunner server.
+ * Handles the runner protocol for active runs and serves the web UI.
+ *
+ * Usage:
+ *   bun serve.ts [--port 9637]
+ *
+ * The CLI registers runs via POST /api/register-run, then launches the
+ * runner process pointing at this server. The CLI connects to
+ * GET /api/runs/:id/events (SSE) for real-time output.
+ */
+import { parseArgs } from "util";
+import { createMultiRunApp, websocket } from "./server/hono";
+import { RunManager } from "./server/runs";
+import { registerWebRoutes } from "./web/routes";
+import { registerApiRoutes } from "./web/api";
+
+const { values } = parseArgs({
+  args: Bun.argv.slice(2),
+  options: {
+    port: { type: "string", default: "9637" },
+  },
+  allowPositionals: false,
+  strict: true,
+});
+
+const port = parseInt(values.port || "9637", 10);
+const runManager = new RunManager();
+const { app, addRunnerCatchAll } = createMultiRunApp(runManager);
+
+// Web UI and API routes (before runner catch-all)
+registerWebRoutes(app);
+registerApiRoutes(app, runManager, port);
+
+// Runner protocol catch-all (must be last)
+addRunnerCatchAll();
+
+const server = Bun.serve({
+  port,
+  fetch: app.fetch,
+  websocket,
+});
+
+console.log(`localrunner server listening on http://localhost:${port}`);
+console.log(`Web UI: http://localhost:${port}/`);
+console.log(`Press Ctrl+C to stop.\n`);
+
+const pidFile = `${process.env.HOME}/.localrunner/server.pid`;
+await Bun.write(pidFile, String(process.pid));
+
+process.on("SIGINT", () => {
+  console.log("\nShutting down...");
+  try { require("fs").unlinkSync(pidFile); } catch {}
+  server.stop(true);
+  process.exit(0);
+});
+
+process.on("SIGTERM", () => {
+  try { require("fs").unlinkSync(pidFile); } catch {}
+  server.stop(true);
+  process.exit(0);
+});

--- a/server/actions.ts
+++ b/server/actions.ts
@@ -1,21 +1,25 @@
+import type { Hono } from "hono";
+import type { ServerEnv } from "./hono";
 import type { OutputHandler } from "../output";
 import type { RunContext } from "./types";
 
-export function actionsHandler(ctx: RunContext) {
-  return async (req: Request): Promise<Response | null> => {
-    const url = new URL(req.url);
-    if (req.method === "POST" && url.pathname.includes("/runnerresolve/actions")) {
-      const body = (await req.json()) as any;
-      const actions = (body.actions || []).map((a: any) => ({
-        action: a.action || a.name,
-        version: a.version || a.ref,
-        path: a.path || "",
-      }));
-      const resolved = await resolveActions(actions, ctx.repoCtx.token, ctx.repoCtx.apiUrl, ctx.output);
-      return Response.json({ actions: resolved });
+export function registerActionsRoutes(app: Hono<ServerEnv>, ctx: RunContext) {
+  // The runner posts to paths like /runnerresolve/actions or /_apis/.../runnerresolve/actions
+  app.post("*", async (c, next) => {
+    const url = new URL(c.req.url);
+    if (!url.pathname.includes("/runnerresolve/actions")) {
+      await next();
+      return;
     }
-    return null;
-  };
+    const body = (await c.req.json()) as any;
+    const actions = (body.actions || []).map((a: any) => ({
+      action: a.action || a.name,
+      version: a.version || a.ref,
+      path: a.path || "",
+    }));
+    const resolved = await resolveActions(actions, ctx.repoCtx.token, ctx.repoCtx.apiUrl, ctx.output);
+    return c.json({ actions: resolved });
+  });
 }
 
 async function resolveActions(

--- a/server/artifacts.ts
+++ b/server/artifacts.ts
@@ -159,32 +159,3 @@ export async function getSignedArtifactURL(ctx: RunContext, body: any): Promise<
   });
 }
 
-export function artifactDownloadHandler(ctx: RunContext) {
-  return async (req: Request): Promise<Response | null> => {
-    const url = new URL(req.url);
-    const path = url.pathname;
-
-    if (!path.startsWith("/_artifacts/")) return null;
-
-    // /_artifacts/{runId}/{name}
-    const parts = path.slice("/_artifacts/".length).split("/");
-    if (parts.length < 2) return new Response("Not found", { status: 404 });
-
-    const runId = parts[0];
-    const name = decodeURIComponent(parts.slice(1).join("/"));
-    const filePath = artifactDataPath(runId, name);
-
-    if (existsSync(filePath)) {
-      const file = Bun.file(filePath);
-      ctx.output.emit({ type: "server", tag: "artifact", message: `Download "${name}" (run=${runId})` });
-      return new Response(file, {
-        headers: {
-          "Content-Type": "application/octet-stream",
-          "Content-Length": String(file.size),
-        },
-      });
-    }
-
-    return new Response("Artifact not found", { status: 404 });
-  };
-}

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -1,39 +1,36 @@
+import type { Hono } from "hono";
+import type { ServerEnv } from "./hono";
 import type { RunContext } from "./types";
 
-export function authRoutes(ctx: RunContext) {
-  return {
-    "/_apis/oauth2/token": {
-      POST: () => {
-        ctx.output.emit({ type: "server", tag: "auth", message: "Token request" });
-        return Response.json({
-          access_token: ctx.jwt,
-          token_type: "Bearer",
-          expires_in: 3600,
-        });
-      },
-    },
-    "/_apis/connectionData": {
-      GET: () => {
-        ctx.output.emit({ type: "server", tag: "connect", message: "Connection data request" });
-        return Response.json(buildConnectionData(ctx));
-      },
-    },
-    "/session": {
-      POST: () => {
-        ctx.output.emit({ type: "server", tag: "session", message: "Created" });
-        return Response.json({
-          sessionId: ctx.sessionId,
-          ownerName: "local",
-          agent: { id: 1, name: "local-runner", version: "2.332.0" },
-          encryptionKey: null,
-        });
-      },
-      DELETE: () => {
-        ctx.output.emit({ type: "server", tag: "session", message: "Deleted" });
-        return Response.json({});
-      },
-    },
-  };
+export function registerAuthRoutes(app: Hono<ServerEnv>, ctx: RunContext) {
+  app.post("/_apis/oauth2/token", (c) => {
+    ctx.output.emit({ type: "server", tag: "auth", message: "Token request" });
+    return c.json({
+      access_token: ctx.jwt,
+      token_type: "Bearer",
+      expires_in: 3600,
+    });
+  });
+
+  app.get("/_apis/connectionData", (c) => {
+    ctx.output.emit({ type: "server", tag: "connect", message: "Connection data request" });
+    return c.json(buildConnectionData(ctx));
+  });
+
+  app.post("/session", (c) => {
+    ctx.output.emit({ type: "server", tag: "session", message: "Created" });
+    return c.json({
+      sessionId: ctx.sessionId,
+      ownerName: "local",
+      agent: { id: 1, name: "local-runner", version: "2.332.0" },
+      encryptionKey: null,
+    });
+  });
+
+  app.delete("/session", (c) => {
+    ctx.output.emit({ type: "server", tag: "session", message: "Deleted" });
+    return c.json({});
+  });
 }
 
 function buildConnectionData(ctx: RunContext): object {

--- a/server/cache.ts
+++ b/server/cache.ts
@@ -1,6 +1,8 @@
 import { join } from "path";
 import { tmpdir } from "os";
 import { mkdirSync, existsSync, readdirSync, unlinkSync, readFileSync } from "fs";
+import type { Hono } from "hono";
+import type { ServerEnv } from "./hono";
 import type { RunContext } from "./types";
 
 interface CacheEntry {
@@ -66,122 +68,116 @@ function findCache(repo: string, keys: string[], version: string): { cacheId: nu
   return null;
 }
 
-export function cacheRoutes(ctx: RunContext) {
+export function registerCacheRoutes(app: Hono<ServerEnv>, ctx: RunContext) {
   const repo = ctx.repoCtx.fullName;
 
-  return {
-    "/_apis/artifactcache/cache": {
-      GET: (req: Request) => {
-        const url = new URL(req.url);
-        const keys = url.searchParams.get("keys")?.split(",") || [];
-        const version = url.searchParams.get("version") || "";
-        ctx.output.emit({ type: "server", tag: "cache", message: `Lookup keys=${keys.join(",")} version=${version.slice(0, 12)}` });
+  app.get("/_apis/artifactcache/cache", (c) => {
+    const url = new URL(c.req.url);
+    const keys = url.searchParams.get("keys")?.split(",") || [];
+    const version = url.searchParams.get("version") || "";
+    ctx.output.emit({ type: "server", tag: "cache", message: `Lookup keys=${keys.join(",")} version=${version.slice(0, 12)}` });
 
-        const found = findCache(repo, keys, version);
-        if (found) {
-          ctx.output.emit({ type: "server", tag: "cache", message: `Hit: ${found.entry.key} (id=${found.cacheId})` });
-          return Response.json({
-            result: "hit",
-            cacheId: found.cacheId,
-            scope: "refs/heads/main",
-            cacheKey: found.entry.key,
-            creationTime: found.entry.createdAt,
-            archiveLocation: `${ctx.serverBaseUrl}/_apis/artifactcache/download/${found.cacheId}`,
-          });
-        }
-        ctx.output.emit({ type: "server", tag: "cache", message: "Miss" });
-        return new Response(null, { status: 204 });
-      },
-    },
-    "/_apis/artifactcache/download/:id": {
-      GET: (req: Request & { params: { id: string } }) => {
-        const cacheId = parseInt(req.params.id);
-        const filePath = cacheEntryPath(repo, cacheId);
-        ctx.output.emit({ type: "server", tag: "cache", message: `Download id=${cacheId}` });
-        if (existsSync(filePath)) {
-          const file = Bun.file(filePath);
-          return new Response(file, {
-            headers: {
-              "Content-Type": "application/octet-stream",
-              "Content-Length": String(file.size),
-            },
-          });
-        }
-        return new Response("Cache not found", { status: 404 });
-      },
-    },
-    "/_apis/artifactcache/caches": {
-      POST: async (req: Request) => {
-        const body = (await req.json()) as any;
-        const cacheId = nextCacheId++;
-        const entry: CacheEntry = {
-          key: body.key,
-          version: body.version || "",
-          committed: false,
-          filePath: cacheEntryPath(repo, cacheId),
-          size: 0,
-          createdAt: new Date().toISOString(),
-        };
-        await Bun.write(cacheMetaPath(repo, cacheId), JSON.stringify(entry));
-        ctx.output.emit({ type: "server", tag: "cache", message: `Reserved id=${cacheId} key=${body.key}` });
-        return Response.json({ cacheId });
-      },
-    },
-    "/_apis/artifactcache/caches/:id": {
-      PATCH: async (req: Request & { params: { id: string } }) => {
-        const cacheId = parseInt(req.params.id);
-        const data = await req.arrayBuffer();
-        const filePath = cacheEntryPath(repo, cacheId);
-        const contentRange = req.headers.get("Content-Range");
-        ctx.output.emit({ type: "server", tag: "cache", message: `Upload id=${cacheId} size=${data.byteLength} range=${contentRange || "full"}` });
+    const found = findCache(repo, keys, version);
+    if (found) {
+      ctx.output.emit({ type: "server", tag: "cache", message: `Hit: ${found.entry.key} (id=${found.cacheId})` });
+      return c.json({
+        result: "hit",
+        cacheId: found.cacheId,
+        scope: "refs/heads/main",
+        cacheKey: found.entry.key,
+        creationTime: found.entry.createdAt,
+        archiveLocation: `${ctx.serverBaseUrl}/_apis/artifactcache/download/${found.cacheId}`,
+      });
+    }
+    ctx.output.emit({ type: "server", tag: "cache", message: "Miss" });
+    return new Response(null, { status: 204 });
+  });
 
-        if (contentRange) {
-          const match = contentRange.match(/bytes (\d+)-(\d+)\//);
-          if (match) {
-            const start = parseInt(match[1]);
-            if (start === 0) {
-              await Bun.write(filePath, data);
-            } else {
-              const existing = existsSync(filePath) ? await Bun.file(filePath).arrayBuffer() : new ArrayBuffer(0);
-              const combined = new Uint8Array(start + data.byteLength);
-              combined.set(new Uint8Array(existing), 0);
-              combined.set(new Uint8Array(data), start);
-              await Bun.write(filePath, combined);
-            }
-          }
-        } else {
+  app.get("/_apis/artifactcache/download/:id", (c) => {
+    const cacheId = parseInt(c.req.param("id"));
+    const filePath = cacheEntryPath(repo, cacheId);
+    ctx.output.emit({ type: "server", tag: "cache", message: `Download id=${cacheId}` });
+    if (existsSync(filePath)) {
+      const file = Bun.file(filePath);
+      return new Response(file, {
+        headers: {
+          "Content-Type": "application/octet-stream",
+          "Content-Length": String(file.size),
+        },
+      });
+    }
+    return new Response("Cache not found", { status: 404 });
+  });
+
+  app.post("/_apis/artifactcache/caches", async (c) => {
+    const body = (await c.req.json()) as any;
+    const cacheId = nextCacheId++;
+    const entry: CacheEntry = {
+      key: body.key,
+      version: body.version || "",
+      committed: false,
+      filePath: cacheEntryPath(repo, cacheId),
+      size: 0,
+      createdAt: new Date().toISOString(),
+    };
+    await Bun.write(cacheMetaPath(repo, cacheId), JSON.stringify(entry));
+    ctx.output.emit({ type: "server", tag: "cache", message: `Reserved id=${cacheId} key=${body.key}` });
+    return c.json({ cacheId });
+  });
+
+  app.patch("/_apis/artifactcache/caches/:id", async (c) => {
+    const cacheId = parseInt(c.req.param("id"));
+    const data = await c.req.arrayBuffer();
+    const filePath = cacheEntryPath(repo, cacheId);
+    const contentRange = c.req.header("Content-Range");
+    ctx.output.emit({ type: "server", tag: "cache", message: `Upload id=${cacheId} size=${data.byteLength} range=${contentRange || "full"}` });
+
+    if (contentRange) {
+      const match = contentRange.match(/bytes (\d+)-(\d+)\//);
+      if (match) {
+        const start = parseInt(match[1]!);
+        if (start === 0) {
           await Bun.write(filePath, data);
+        } else {
+          const existing = existsSync(filePath) ? await Bun.file(filePath).arrayBuffer() : new ArrayBuffer(0);
+          const combined = new Uint8Array(start + data.byteLength);
+          combined.set(new Uint8Array(existing), 0);
+          combined.set(new Uint8Array(data), start);
+          await Bun.write(filePath, combined);
         }
-        return new Response(null, { status: 204 });
-      },
-      POST: async (req: Request & { params: { id: string } }) => {
-        const cacheId = parseInt(req.params.id);
-        const body = (await req.json()) as any;
-        const metaPath = cacheMetaPath(repo, cacheId);
+      }
+    } else {
+      await Bun.write(filePath, data);
+    }
+    return new Response(null, { status: 204 });
+  });
 
-        if (existsSync(metaPath)) {
-          const meta: CacheEntry = JSON.parse(readFileSync(metaPath, "utf8"));
-          meta.committed = true;
-          meta.size = body.size || 0;
+  app.post("/_apis/artifactcache/caches/:id", async (c) => {
+    const cacheId = parseInt(c.req.param("id"));
+    const body = (await c.req.json()) as any;
+    const metaPath = cacheMetaPath(repo, cacheId);
 
-          const dir = getCacheDir(repo);
-          for (const f of readdirSync(dir).filter(f => f.endsWith(".json"))) {
-            const fPath = join(dir, f);
-            if (fPath === metaPath) continue;
-            try {
-              const existing: CacheEntry = JSON.parse(readFileSync(fPath, "utf8"));
-              if (existing.key === meta.key && existing.version === meta.version) {
-                const oldId = parseInt(f.replace("cache-", "").replace(".json", ""));
-                removeCacheEntry(repo, oldId);
-              }
-            } catch {}
+    if (existsSync(metaPath)) {
+      const meta: CacheEntry = JSON.parse(readFileSync(metaPath, "utf8"));
+      meta.committed = true;
+      meta.size = body.size || 0;
+
+      const dir = getCacheDir(repo);
+      for (const f of readdirSync(dir).filter(f => f.endsWith(".json"))) {
+        const fPath = join(dir, f);
+        if (fPath === metaPath) continue;
+        try {
+          const existing: CacheEntry = JSON.parse(readFileSync(fPath, "utf8"));
+          if (existing.key === meta.key && existing.version === meta.version) {
+            const oldId = parseInt(f.replace("cache-", "").replace(".json", ""));
+            removeCacheEntry(repo, oldId);
           }
+        } catch {}
+      }
 
-          await Bun.write(metaPath, JSON.stringify(meta));
-          ctx.output.emit({ type: "server", tag: "cache", message: `Committed id=${cacheId} key=${meta.key} size=${meta.size}` });
-        }
-        return new Response(null, { status: 204 });
-      },
-    },
-  };
+      await Bun.write(metaPath, JSON.stringify(meta));
+      ctx.output.emit({ type: "server", tag: "cache", message: `Committed id=${cacheId} key=${meta.key} size=${meta.size}` });
+    }
+    return new Response(null, { status: 204 });
+  });
 }

--- a/server/hono.ts
+++ b/server/hono.ts
@@ -1,0 +1,138 @@
+import { Hono } from "hono";
+import { createBunWebSocket } from "hono/bun";
+import type { RunContext } from "./types";
+import type { RunManager } from "./runs";
+import { registerAuthRoutes } from "./auth";
+import { registerJobRoutes } from "./job";
+import { registerCacheRoutes } from "./cache";
+import { registerActionsRoutes } from "./actions";
+import { registerResultsRoutes } from "./results";
+import { registerLogsRoutes } from "./logs";
+
+export type ServerEnv = {
+  Variables: {
+    ctx: RunContext;
+  };
+};
+
+const { upgradeWebSocket, websocket } = createBunWebSocket();
+
+export { websocket };
+
+function registerRunnerRoutes(app: Hono<ServerEnv>, ctx: RunContext) {
+  registerAuthRoutes(app, ctx);
+  registerJobRoutes(app, ctx);
+  registerCacheRoutes(app, ctx);
+  registerActionsRoutes(app, ctx);
+  registerResultsRoutes(app, ctx);
+  registerLogsRoutes(app, ctx, upgradeWebSocket);
+}
+
+/**
+ * Create a Hono app for the ephemeral single-run server (backwards compat).
+ */
+export function createApp(ctx: RunContext) {
+  const app = new Hono<ServerEnv>();
+
+  app.use("*", async (c, next) => {
+    c.set("ctx", ctx);
+    const url = new URL(c.req.url);
+    ctx.output.emit({
+      type: "server",
+      tag: c.req.method,
+      message: `${url.pathname}${url.search}`,
+    });
+    await next();
+  });
+
+  registerRunnerRoutes(app, ctx);
+
+  app.all("*", (c) => {
+    ctx.output.emit({
+      type: "server",
+      tag: "unhandled",
+      message: `${c.req.method} ${new URL(c.req.url).pathname}`,
+    });
+    return c.json({});
+  });
+
+  return app;
+}
+
+/** Create a per-run Hono sub-app with all runner protocol routes. */
+function createRunApp(ctx: RunContext): Hono<ServerEnv> {
+  const app = new Hono<ServerEnv>();
+  registerRunnerRoutes(app, ctx);
+  app.all("*", (c) => {
+    ctx.output.emit({
+      type: "server",
+      tag: "unhandled",
+      message: `${c.req.method} ${new URL(c.req.url).pathname}`,
+    });
+    return c.json({});
+  });
+  return app;
+}
+
+/**
+ * Resolve RunContext from a request by parsing the JWT in the Authorization header.
+ * Falls back to single active run if only one exists.
+ */
+function resolveRun(req: Request, runManager: RunManager): RunContext | undefined {
+  // Try JWT from Authorization header
+  const auth = req.headers.get("Authorization");
+  if (auth?.startsWith("Bearer ")) {
+    const ctx = runManager.getRunFromJwt(auth.slice(7));
+    if (ctx) return ctx;
+  }
+
+  // Fallback: if only one active run, use it
+  const active = runManager.getActiveRuns();
+  if (active.length === 1) return active[0];
+
+  return undefined;
+}
+
+/**
+ * Create the long-lived multi-run Hono app.
+ *
+ * Runner identification: the runner receives a JWT (via /_apis/oauth2/token)
+ * containing the runId in its `scp` claim. It sends this JWT as
+ * `Authorization: Bearer {jwt}` on all subsequent requests.
+ * We decode the JWT to route each request to the correct RunContext.
+ */
+export function createMultiRunApp(runManager: RunManager) {
+  const app = new Hono();
+
+  // Health check (web UI / CLI)
+  app.get("/api/health", (c) => c.json({ ok: true }));
+
+  /**
+   * Call AFTER registering all web UI and API routes on `app`.
+   * Adds the catch-all that dispatches runner protocol requests to per-run sub-apps.
+   */
+  function addRunnerCatchAll() {
+    app.all("*", async (c) => {
+      const ctx = resolveRun(c.req.raw, runManager);
+      if (!ctx) {
+        return c.json({ error: "No active run found" }, 404);
+      }
+
+      const url = new URL(c.req.url);
+      ctx.output.emit({
+        type: "server",
+        tag: c.req.method,
+        message: `${url.pathname}${url.search}`,
+      });
+
+      if (!ctx._app) {
+        ctx._app = createRunApp(ctx);
+      }
+
+      // Pass env through so Hono's Bun adapter can access the server (needed for WebSocket upgrade)
+      return ctx._app.fetch(c.req.raw, c.env);
+    });
+  }
+
+  return { app, addRunnerCatchAll };
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,12 +1,6 @@
 import { createRunContext } from "./types";
 import type { ServerConfig, ServerHandle } from "./types";
-import { authRoutes } from "./auth";
-import { jobRoutes } from "./job";
-import { cacheRoutes } from "./cache";
-import { actionsHandler } from "./actions";
-import { resultsHandler } from "./results";
-import { logsHandler, websocketHandlers } from "./logs";
-import { artifactDownloadHandler } from "./artifacts";
+import { createApp, websocket } from "./hono";
 
 export { scriptStep, actionStep } from "./steps";
 export type { ServerConfig, ServerHandle } from "./types";
@@ -15,52 +9,12 @@ export function createServer(config: ServerConfig): ServerHandle {
   const { ctx, jobCompleted } = createRunContext(config);
   const { output } = ctx;
 
-  // Build wildcard handlers (for paths with dynamic segments the router can't match)
-  const handleActions = actionsHandler(ctx);
-  const handleResults = resultsHandler(ctx);
-  const handleLogs = logsHandler(ctx);
-  const handleArtifacts = artifactDownloadHandler(ctx);
+  const app = createApp(ctx);
 
   const server = Bun.serve({
     port: ctx.port,
-    routes: {
-      ...authRoutes(ctx),
-      ...jobRoutes(ctx),
-      ...cacheRoutes(ctx),
-    },
-
-    async fetch(req) {
-      const url = new URL(req.url);
-      const path = url.pathname;
-      const method = req.method;
-
-      output.emit({ type: "server", tag: method, message: `${path}${url.search}` });
-
-      // Try wildcard handlers in order
-      const actionsRes = await handleActions(req);
-      if (actionsRes) return actionsRes;
-
-      const resultsRes = await handleResults(req);
-      if (resultsRes) return resultsRes;
-
-      const artifactsRes = await handleArtifacts(req);
-      if (artifactsRes) return artifactsRes;
-
-      // Feed WebSocket upgrade needs special handling
-      if (path.includes("/feed") && req.headers.get("upgrade")?.toLowerCase() === "websocket") {
-        const upgraded = server.upgrade(req);
-        if (upgraded) return undefined as any;
-        return new Response("WebSocket upgrade failed", { status: 400 });
-      }
-
-      const logsRes = await handleLogs(req);
-      if (logsRes) return logsRes;
-
-      output.emit({ type: "server", tag: "unhandled", message: `${method} ${path}` });
-      return Response.json({});
-    },
-
-    websocket: websocketHandlers(ctx),
+    fetch: app.fetch,
+    websocket,
   });
 
   output.emit({ type: "info", message: `Local Actions server listening on http://localhost:${ctx.port}` });

--- a/server/job.ts
+++ b/server/job.ts
@@ -1,77 +1,75 @@
 import { randomUUID } from "crypto";
+import type { Hono } from "hono";
+import type { ServerEnv } from "./hono";
 import { buildGitHubContextData } from "../context";
 import type { RunContext } from "./types";
 import { getDb } from "../db";
 import { runs, jobs } from "../db/schema";
 import { eq } from "drizzle-orm";
 
-export function jobRoutes(ctx: RunContext) {
-  return {
-    "/message": {
-      GET: () => {
-        if (!ctx.jobDispatched) {
-          ctx.jobDispatched = true;
-          ctx.output.emit({ type: "server", tag: "message", message: "Dispatching job!" });
-          return Response.json({
-            messageId: 1,
-            messageType: "RunnerJobRequest",
-            iv: null,
-            body: JSON.stringify({
-              id: "msg-1",
-              runner_request_id: "req-1",
-              run_service_url: ctx.serverBaseUrl,
-              should_acknowledge: false,
-              billing_owner_id: "",
-            }),
-          });
-        }
-        if (ctx.jobDone) {
-          return new Response(null, { status: 200 });
-        }
-        return new Promise((resolve) => {
-          setTimeout(() => resolve(new Response(null, { status: 200 })), 5000);
-        });
-      },
-    },
-    "/acknowledge": { POST: () => Response.json({}) },
-    "/acquirejob": {
-      POST: () => {
-        ctx.output.emit({ type: "server", tag: "job", message: "Job acquired" });
-        return Response.json(buildJobMessage(ctx));
-      },
-    },
-    "/renewjob": {
-      POST: () => Response.json({
-        lockedUntil: new Date(Date.now() + 3600000).toISOString(),
-      }),
-    },
-    "/completejob": {
-      POST: async (req: Request) => {
-        ctx.jobDone = true;
-        const body = await req.json() as any;
-        const conclusion = body.conclusion || "unknown";
-        ctx.output.emit({ type: "server", tag: "job", message: `Job completed (${conclusion})` });
-        ctx.output.emit({ type: "job_complete", conclusion });
+export function registerJobRoutes(app: Hono<ServerEnv>, ctx: RunContext) {
+  app.get("/message", (c) => {
+    if (!ctx.jobDispatched) {
+      ctx.jobDispatched = true;
+      ctx.output.emit({ type: "server", tag: "message", message: "Dispatching job!" });
+      return c.json({
+        messageId: 1,
+        messageType: "RunnerJobRequest",
+        iv: null,
+        body: JSON.stringify({
+          id: "msg-1",
+          runner_request_id: "req-1",
+          run_service_url: ctx.serverBaseUrl,
+          should_acknowledge: false,
+          billing_owner_id: "",
+        }),
+      });
+    }
+    if (ctx.jobDone) {
+      return new Response(null, { status: 200 });
+    }
+    return new Promise<Response>((resolve) => {
+      setTimeout(() => resolve(new Response(null, { status: 200 })), 5000);
+    });
+  });
 
-        ctx.output.flushAllLogs();
-        try {
-          const db = getDb();
-          const now = Date.now();
-          db.update(jobs)
-            .set({ status: "completed", conclusion, completedAt: now })
-            .where(eq(jobs.id, ctx.jobId))
-            .run();
-          db.update(runs)
-            .set({ status: "completed", conclusion, completedAt: now })
-            .where(eq(runs.id, ctx.runId))
-            .run();
-        } catch {}
+  app.post("/acknowledge", (c) => c.json({}));
 
-        ctx.resolveJobCompleted(conclusion);
-        return Response.json({});
-      },
-    },
-  };
+  app.post("/acquirejob", (c) => {
+    ctx.output.emit({ type: "server", tag: "job", message: "Job acquired" });
+    return c.json(buildJobMessage(ctx));
+  });
+
+  app.post("/renewjob", (c) =>
+    c.json({
+      lockedUntil: new Date(Date.now() + 3600000).toISOString(),
+    })
+  );
+
+  app.post("/completejob", async (c) => {
+    ctx.jobDone = true;
+    const body = (await c.req.json()) as any;
+    const conclusion = body.conclusion || "unknown";
+    ctx.output.emit({ type: "server", tag: "job", message: `Job completed (${conclusion})` });
+    ctx.output.emit({ type: "job_complete", conclusion });
+
+    ctx.output.flushAllLogs();
+    try {
+      const db = getDb();
+      const now = Date.now();
+      db.update(jobs)
+        .set({ status: "completed", conclusion, completedAt: now })
+        .where(eq(jobs.id, ctx.jobId))
+        .run();
+      db.update(runs)
+        .set({ status: "completed", conclusion, completedAt: now })
+        .where(eq(runs.id, ctx.runId))
+        .run();
+    } catch {}
+
+    ctx.resolveJobCompleted(conclusion);
+    return c.json({});
+  });
 }
 
 function buildJobMessage(ctx: RunContext): object {

--- a/server/logs.ts
+++ b/server/logs.ts
@@ -1,96 +1,103 @@
+import type { Hono } from "hono";
+import type { ServerEnv } from "./hono";
 import type { RunContext } from "./types";
 
-export function logsHandler(ctx: RunContext) {
-  return async (req: Request): Promise<Response | null> => {
-    const url = new URL(req.url);
-    const path = url.pathname;
-    const method = req.method;
-
-    // Log uploads
-    if (path.includes("/logs")) {
-      if (method === "POST" && path.match(/\/logs\/\d+/)) {
-        const text = await req.text();
-        for (const line of text.split("\n")) {
-          if (line.trim()) ctx.output.emit({ type: "step_log", line: line.trim() });
-        }
-      }
-      return Response.json({ id: 1, path: "logs/1" });
+export function registerLogsRoutes(
+  app: Hono<ServerEnv>,
+  ctx: RunContext,
+  upgradeWebSocket: (handler: any) => any,
+) {
+  // Log uploads
+  app.post("/logs/:id", async (c) => {
+    const text = await c.req.text();
+    for (const line of text.split("\n")) {
+      if (line.trim()) ctx.output.emit({ type: "step_log", line: line.trim() });
     }
+    return c.json({ id: 1, path: "logs/1" });
+  });
 
-    // Feed - WebSocket upgrade
-    if (path.includes("/feed")) {
-      if (req.headers.get("upgrade")?.toLowerCase() === "websocket") {
-        // Return null to signal caller should attempt upgrade
-        return null;
-      }
-      const text = await req.text();
-      for (const line of text.split("\n")) {
-        if (line.trim()) ctx.output.emit({ type: "step_log", line: line.trim() });
-      }
-      return Response.json({});
-    }
+  // Catch-all for other /logs/* paths
+  app.all("/logs/*", (c) => {
+    return c.json({ id: 1, path: "logs/1" });
+  });
 
-    // Timeline updates
-    if (path.includes("/timelines")) {
-      if (method === "POST") {
-        return Response.json({ id: ctx.timelineId, changeId: 1, records: [] });
-      }
-      if (method === "PATCH") {
-        const body = await req.json() as any;
-        const records = body.value || body;
-        if (Array.isArray(records)) {
-          const results = ["Succeeded", "SucceededWithIssues", "Failed", "Cancelled", "Skipped", "Abandoned"];
-          for (const record of records) {
-            if (record.name && record.state !== undefined) {
-              if (record.state === 1) {
-                ctx.output.emit({ type: "step_start", stepName: record.name, timestamp: Date.now() });
-              } else if (record.state === 2) {
-                const result = record.result != null ? (results[record.result] || String(record.result)) : "unknown";
-                ctx.output.emit({ type: "step_complete", stepName: record.name, conclusion: result.toLowerCase(), timestamp: Date.now() });
+  // Feed - WebSocket upgrade
+  app.get(
+    "/feed",
+    upgradeWebSocket(() => ({
+      onOpen(_event: any, ws: any) {
+        ctx.output.emit({ type: "server", tag: "feed", message: "WebSocket connected" });
+      },
+      onMessage(event: any, ws: any) {
+        const message = event.data;
+        try {
+          const data = JSON.parse(typeof message === "string" ? message : new TextDecoder().decode(message));
+          if (data.value && Array.isArray(data.value)) {
+            for (const line of data.value) {
+              if (typeof line === "string" && line.trim()) {
+                ctx.output.emit({ type: "step_log", line: line.trim() });
               }
             }
           }
+        } catch {
+          const text = typeof message === "string" ? message : new TextDecoder().decode(message);
+          if (text.trim()) ctx.output.emit({ type: "step_log", line: text.trim() });
         }
-        return Response.json({ changeId: 2, records: [] });
-      }
-      if (method === "GET") {
-        return Response.json({ id: ctx.timelineId, changeId: 1, records: [] });
-      }
+      },
+      onClose(_event: any, ws: any) {
+        ctx.output.emit({ type: "server", tag: "feed", message: "WebSocket closed" });
+      },
+    })),
+  );
+
+  // Non-WebSocket feed posts (fallback)
+  app.post("/feed", async (c) => {
+    const text = await c.req.text();
+    for (const line of text.split("\n")) {
+      if (line.trim()) ctx.output.emit({ type: "step_log", line: line.trim() });
     }
+    return c.json({});
+  });
 
-    // Events
-    if (path.includes("/events")) {
-      const body = await req.json() as any;
-      ctx.output.emit({ type: "server", tag: "event", message: body.name || "unknown" });
-      return Response.json({});
-    }
+  // Timeline updates
+  app.post("/timelines/*", (c) => {
+    return c.json({ id: ctx.timelineId, changeId: 1, records: [] });
+  });
 
-    return null;
-  };
-}
-
-export function websocketHandlers(ctx: RunContext) {
-  return {
-    open(ws: any) {
-      ctx.output.emit({ type: "server", tag: "feed", message: "WebSocket connected" });
-    },
-    message(ws: any, message: any) {
-      try {
-        const data = JSON.parse(typeof message === "string" ? message : new TextDecoder().decode(message));
-        if (data.value && Array.isArray(data.value)) {
-          for (const line of data.value) {
-            if (typeof line === "string" && line.trim()) {
-              ctx.output.emit({ type: "step_log", line: line.trim() });
-            }
+  app.patch("/timelines/*", async (c) => {
+    const body = (await c.req.json()) as any;
+    const records = body.value || body;
+    if (Array.isArray(records)) {
+      const results = ["Succeeded", "SucceededWithIssues", "Failed", "Cancelled", "Skipped", "Abandoned"];
+      for (const record of records) {
+        if (record.name && record.state !== undefined) {
+          if (record.state === 1) {
+            ctx.output.emit({ type: "step_start", stepName: record.name, timestamp: Date.now() });
+          } else if (record.state === 2) {
+            const result = record.result != null ? (results[record.result] || String(record.result)) : "unknown";
+            ctx.output.emit({ type: "step_complete", stepName: record.name, conclusion: result.toLowerCase(), timestamp: Date.now() });
           }
         }
-      } catch {
-        const text = typeof message === "string" ? message : new TextDecoder().decode(message);
-        if (text.trim()) ctx.output.emit({ type: "step_log", line: text.trim() });
       }
-    },
-    close(ws: any) {
-      ctx.output.emit({ type: "server", tag: "feed", message: "WebSocket closed" });
-    },
-  };
+    }
+    return c.json({ changeId: 2, records: [] });
+  });
+
+  app.get("/timelines/*", (c) => {
+    return c.json({ id: ctx.timelineId, changeId: 1, records: [] });
+  });
+
+  // Events
+  app.post("/events/*", async (c) => {
+    const body = (await c.req.json()) as any;
+    ctx.output.emit({ type: "server", tag: "event", message: body.name || "unknown" });
+    return c.json({});
+  });
+
+  // Catch events at root level too
+  app.post("/events", async (c) => {
+    const body = (await c.req.json()) as any;
+    ctx.output.emit({ type: "server", tag: "event", message: body.name || "unknown" });
+    return c.json({});
+  });
 }

--- a/server/results.ts
+++ b/server/results.ts
@@ -1,4 +1,6 @@
 import { randomUUID } from "crypto";
+import type { Hono } from "hono";
+import type { ServerEnv } from "./hono";
 import type { RunContext } from "./types";
 import {
   createArtifact,
@@ -9,136 +11,148 @@ import {
   getArtifactBlobPath,
 } from "./artifacts";
 
-export function resultsHandler(ctx: RunContext) {
-  return async (req: Request): Promise<Response | null> => {
-    const url = new URL(req.url);
-    const path = url.pathname;
-    const method = req.method;
+export function registerResultsRoutes(app: Hono<ServerEnv>, ctx: RunContext) {
+  // Twirp endpoints
+  app.post("/twirp/*", async (c) => {
+    const path = new URL(c.req.url).pathname;
+    const body = (await c.req.json()) as any;
 
-    // Results API - Twirp endpoints
-    if (path.startsWith("/twirp/")) {
-      const body = await req.json() as any;
-
-      if (path.includes("WorkflowStepsUpdate")) {
-        const conclusionNames: Record<number, string> = { 2: "succeeded", 3: "failed", 4: "cancelled", 7: "skipped" };
-        if (body.steps) {
-          for (const step of body.steps) {
-            if (step.name) {
-              if (step.status === 3) {
-                ctx.output.emit({ type: "step_start", stepName: step.name, timestamp: Date.now() });
-              } else if (step.status === 6) {
-                const conclusion = conclusionNames[step.conclusion] || "unknown";
-                ctx.output.emit({ type: "step_complete", stepName: step.name, conclusion, timestamp: Date.now() });
-              }
+    if (path.includes("WorkflowStepsUpdate")) {
+      const conclusionNames: Record<number, string> = { 2: "succeeded", 3: "failed", 4: "cancelled", 7: "skipped" };
+      if (body.steps) {
+        for (const step of body.steps) {
+          if (step.name) {
+            if (step.status === 3) {
+              ctx.output.emit({ type: "step_start", stepName: step.name, timestamp: Date.now() });
+            } else if (step.status === 6) {
+              const conclusion = conclusionNames[step.conclusion] || "unknown";
+              ctx.output.emit({ type: "step_complete", stepName: step.name, conclusion, timestamp: Date.now() });
             }
           }
         }
-        return Response.json({ stepsResult: [] });
       }
-
-      if (path.includes("SignedBlobURL")) {
-        const blobId = randomUUID();
-        // If this blob is for an artifact upload, register it
-        if (body.artifact_name) {
-          const runId = body.workflow_run_backend_id || ctx.runId;
-          registerArtifactBlob(blobId, runId, body.artifact_name);
-        }
-        return Response.json({
-          url: `${ctx.serverBaseUrl}/_blob/${blobId}`,
-          blob_storage_type: "BLOB_STORAGE_TYPE_AZURE",
-          soft_size_limit: 104857600,
-        });
-      }
-
-      if (path.includes("CreateArtifact")) {
-        return createArtifact(ctx, body);
-      }
-
-      if (path.includes("FinalizeArtifact")) {
-        return finalizeArtifact(ctx, body);
-      }
-
-      if (path.includes("ListArtifacts")) {
-        return listArtifacts(ctx, body);
-      }
-
-      if (path.includes("GetSignedArtifactURL")) {
-        return getSignedArtifactURL(ctx, body);
-      }
-
-      if (path.includes("Metadata")) {
-        return Response.json({ ok: true });
-      }
-
-      ctx.output.emit({ type: "server", tag: "twirp", message: path });
-      return Response.json({});
+      return c.json({ stepsResult: [] });
     }
 
-    // Blob upload endpoint (for Results API log uploads and artifact uploads)
-    if (path.startsWith("/_blob/")) {
-      if (method === "PUT" || method === "PATCH" || method === "POST") {
-        const blobId = path.slice("/_blob/".length);
-        const artifactPath = getArtifactBlobPath(blobId);
-
-        if (artifactPath) {
-          // This blob is an artifact upload — persist to disk
-          const data = await req.arrayBuffer();
-          await Bun.write(artifactPath, data);
-          ctx.output.emit({ type: "server", tag: "artifact", message: `Blob upload ${blobId} (${data.byteLength} bytes)` });
-        } else {
-          // Regular log blob
-          const text = await req.text();
-          for (const line of text.split("\n")) {
-            if (line.trim()) ctx.output.emit({ type: "step_log", line: line.trim() });
-          }
-        }
+    if (path.includes("SignedBlobURL")) {
+      const blobId = randomUUID();
+      if (body.artifact_name) {
+        const runId = body.workflow_run_backend_id || ctx.runId;
+        registerArtifactBlob(blobId, runId, body.artifact_name);
       }
-      return new Response(null, { status: 201, headers: { "x-ms-request-id": randomUUID() } });
+      return c.json({
+        url: `${ctx.serverBaseUrl}/_blob/${blobId}`,
+        blob_storage_type: "BLOB_STORAGE_TYPE_AZURE",
+        soft_size_limit: 104857600,
+      });
     }
 
-    // Artifact blob upload endpoint (Azure SDK compatible)
-    // URL format: /localartifact/upload/{blobId}?comp=block&blockid=...
-    // Azure SDK uploads blocks then commits with comp=blocklist
-    if (path.startsWith("/localartifact/upload/")) {
-      const blobId = path.slice("/localartifact/upload/".length);
+    if (path.includes("CreateArtifact")) {
+      return createArtifact(ctx, body);
+    }
+
+    if (path.includes("FinalizeArtifact")) {
+      return finalizeArtifact(ctx, body);
+    }
+
+    if (path.includes("ListArtifacts")) {
+      return listArtifacts(ctx, body);
+    }
+
+    if (path.includes("GetSignedArtifactURL")) {
+      return getSignedArtifactURL(ctx, body);
+    }
+
+    if (path.includes("Metadata")) {
+      return c.json({ ok: true });
+    }
+
+    ctx.output.emit({ type: "server", tag: "twirp", message: path });
+    return c.json({});
+  });
+
+  // Blob upload endpoint
+  app.all("/_blob/:blobId", async (c) => {
+    const method = c.req.method;
+    const blobId = c.req.param("blobId");
+
+    if (method === "PUT" || method === "PATCH" || method === "POST") {
       const artifactPath = getArtifactBlobPath(blobId);
-      const comp = url.searchParams.get("comp");
 
-      if (comp === "blocklist") {
-        // Block list commit — artifact upload is complete
-        ctx.output.emit({ type: "server", tag: "artifact", message: `Block list committed for ${blobId}` });
-        return new Response(null, { status: 201, headers: { "x-ms-request-id": randomUUID(), "x-ms-content-crc64": "" } });
-      }
-
-      if (comp === "block") {
-        // Individual block upload — append to artifact file
-        if (artifactPath) {
-          const data = await req.arrayBuffer();
-          const { existsSync } = await import("fs");
-          if (existsSync(artifactPath)) {
-            // Append to existing file
-            const existing = await Bun.file(artifactPath).arrayBuffer();
-            const combined = new Uint8Array(existing.byteLength + data.byteLength);
-            combined.set(new Uint8Array(existing), 0);
-            combined.set(new Uint8Array(data), existing.byteLength);
-            await Bun.write(artifactPath, combined);
-          } else {
-            await Bun.write(artifactPath, data);
-          }
-          ctx.output.emit({ type: "server", tag: "artifact", message: `Block upload ${blobId} (${data.byteLength} bytes)` });
-        }
-        return new Response(null, { status: 201, headers: { "x-ms-request-id": randomUUID(), "x-ms-content-md5": "" } });
-      }
-
-      // Simple PUT (no chunking)
-      if (method === "PUT" && artifactPath) {
-        const data = await req.arrayBuffer();
+      if (artifactPath) {
+        const data = await c.req.arrayBuffer();
         await Bun.write(artifactPath, data);
-        ctx.output.emit({ type: "server", tag: "artifact", message: `Upload ${blobId} (${data.byteLength} bytes)` });
+        ctx.output.emit({ type: "server", tag: "artifact", message: `Blob upload ${blobId} (${data.byteLength} bytes)` });
+      } else {
+        const text = await c.req.text();
+        for (const line of text.split("\n")) {
+          if (line.trim()) ctx.output.emit({ type: "step_log", line: line.trim() });
+        }
       }
-      return new Response(null, { status: 201, headers: { "x-ms-request-id": randomUUID() } });
+    }
+    return new Response(null, { status: 201, headers: { "x-ms-request-id": randomUUID() } });
+  });
+
+  // Artifact blob upload endpoint (Azure SDK compatible)
+  app.all("/localartifact/upload/:blobId", async (c) => {
+    const blobId = c.req.param("blobId");
+    const artifactPath = getArtifactBlobPath(blobId);
+    const url = new URL(c.req.url);
+    const comp = url.searchParams.get("comp");
+
+    if (comp === "blocklist") {
+      ctx.output.emit({ type: "server", tag: "artifact", message: `Block list committed for ${blobId}` });
+      return new Response(null, { status: 201, headers: { "x-ms-request-id": randomUUID(), "x-ms-content-crc64": "" } });
     }
 
-    return null;
-  };
+    if (comp === "block") {
+      if (artifactPath) {
+        const data = await c.req.arrayBuffer();
+        const { existsSync } = await import("fs");
+        if (existsSync(artifactPath)) {
+          const existing = await Bun.file(artifactPath).arrayBuffer();
+          const combined = new Uint8Array(existing.byteLength + data.byteLength);
+          combined.set(new Uint8Array(existing), 0);
+          combined.set(new Uint8Array(data), existing.byteLength);
+          await Bun.write(artifactPath, combined);
+        } else {
+          await Bun.write(artifactPath, data);
+        }
+        ctx.output.emit({ type: "server", tag: "artifact", message: `Block upload ${blobId} (${data.byteLength} bytes)` });
+      }
+      return new Response(null, { status: 201, headers: { "x-ms-request-id": randomUUID(), "x-ms-content-md5": "" } });
+    }
+
+    // Simple PUT (no chunking)
+    if (c.req.method === "PUT" && artifactPath) {
+      const data = await c.req.arrayBuffer();
+      await Bun.write(artifactPath, data);
+      ctx.output.emit({ type: "server", tag: "artifact", message: `Upload ${blobId} (${data.byteLength} bytes)` });
+    }
+    return new Response(null, { status: 201, headers: { "x-ms-request-id": randomUUID() } });
+  });
+
+  // Artifact download endpoint
+  app.get("/_artifacts/:runId/:name{.+}", async (c) => {
+    const runId = c.req.param("runId");
+    const name = decodeURIComponent(c.req.param("name"));
+    const { existsSync } = await import("fs");
+    const { join } = await import("path");
+    const { homedir } = await import("os");
+
+    const filePath = join(homedir(), ".localrunner", "runs", runId, "artifacts", name);
+
+    if (existsSync(filePath)) {
+      const file = Bun.file(filePath);
+      ctx.output.emit({ type: "server", tag: "artifact", message: `Download "${name}" (run=${runId})` });
+      return new Response(file, {
+        headers: {
+          "Content-Type": "application/octet-stream",
+          "Content-Length": String(file.size),
+        },
+      });
+    }
+
+    return new Response("Artifact not found", { status: 404 });
+  });
 }

--- a/server/runs.ts
+++ b/server/runs.ts
@@ -1,0 +1,52 @@
+import { createRunContext } from "./types";
+import type { ServerConfig, RunContext } from "./types";
+
+/**
+ * RunManager tracks active runs on the server.
+ * Runs are identified by JWT token: the runner gets a JWT containing
+ * the runId in its `scp` claim, and sends it as Authorization: Bearer
+ * on all requests after the initial token exchange.
+ */
+export class RunManager {
+  private activeRuns = new Map<string, RunContext>();
+
+  registerRun(config: ServerConfig): { ctx: RunContext; jobCompleted: Promise<string> } {
+    const { ctx, jobCompleted } = createRunContext(config);
+    this.activeRuns.set(ctx.runId, ctx);
+    return { ctx, jobCompleted };
+  }
+
+  getRunByRunId(runId: string): RunContext | undefined {
+    return this.activeRuns.get(runId);
+  }
+
+  /**
+   * Extract runId from a JWT's scp claim and look up the run.
+   * JWT payload.scp = "Actions.Results:{runId}:{jobId}"
+   */
+  getRunFromJwt(jwt: string): RunContext | undefined {
+    try {
+      const parts = jwt.split(".");
+      if (parts.length !== 3) return undefined;
+      const payload = JSON.parse(Buffer.from(parts[1]!, "base64url").toString());
+      const scp = payload.scp as string;
+      if (!scp) return undefined;
+      const runId = scp.split(":")[1];
+      return runId ? this.activeRuns.get(runId) : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  completeRun(runId: string) {
+    this.activeRuns.delete(runId);
+  }
+
+  getActiveRuns(): RunContext[] {
+    return Array.from(this.activeRuns.values());
+  }
+
+  hasActiveRuns(): boolean {
+    return this.activeRuns.size > 0;
+  }
+}

--- a/server/types.ts
+++ b/server/types.ts
@@ -54,6 +54,9 @@ export interface RunContext {
   jobDispatched: boolean;
   jobDone: boolean;
   resolveJobCompleted: (conclusion: string) => void;
+
+  /** Cached per-run Hono app (set lazily by the multi-run server) */
+  _app?: import("hono").Hono;
 }
 
 export function createRunContext(config: ServerConfig): { ctx: RunContext; jobCompleted: Promise<string> } {

--- a/web/api.ts
+++ b/web/api.ts
@@ -1,0 +1,109 @@
+import type { Hono } from "hono";
+import { streamSSE } from "hono/streaming";
+import type { RunManager } from "../server/runs";
+import type { ServerConfig } from "../server/types";
+import { OutputHandler, type RunEvent } from "../output";
+import { getDb } from "../db";
+import { runs, jobs, steps, stepLogs } from "../db/schema";
+import { eq, desc } from "drizzle-orm";
+
+export function registerApiRoutes(app: Hono, runManager: RunManager, port: number) {
+  /**
+   * Register a new run on the server.
+   * The CLI calls this, then launches the runner process itself.
+   * Returns runId/jobId so the CLI can build the JIT config.
+   */
+  app.post("/api/register-run", async (c) => {
+    const body = (await c.req.json()) as {
+      config: Omit<ServerConfig, "port" | "output">;
+    };
+
+    const output = new OutputHandler("verbose");
+    const { ctx, jobCompleted } = runManager.registerRun({
+      ...body.config,
+      port,
+      output,
+    });
+
+    // The jobCompleted promise is monitored so we can clean up
+    // when the runner finishes (via the completejob endpoint)
+    jobCompleted.then(() => {
+      runManager.completeRun(ctx.runId);
+    }).catch(() => {
+      runManager.completeRun(ctx.runId);
+    });
+
+    return c.json({
+      runId: ctx.runId,
+      jobId: ctx.jobId,
+    });
+  });
+
+  /**
+   * SSE stream of output events for an active run.
+   * The CLI connects here after registering a run to get real-time output.
+   */
+  app.get("/api/runs/:id/events", (c) => {
+    const runId = c.req.param("id");
+    const ctx = runManager.getRunByRunId(runId);
+    if (!ctx) {
+      return c.json({ error: "Run not found or not active" }, 404);
+    }
+
+    return streamSSE(c, async (stream) => {
+      let closed = false;
+      stream.onAbort(() => { closed = true; });
+
+      // Send an initial comment so the response headers flush immediately
+      await stream.writeSSE({ data: "", event: "keepalive" });
+
+      const unsubscribe = ctx.output.subscribe((event: RunEvent) => {
+        if (closed) return;
+        stream.writeSSE({
+          event: event.type,
+          data: JSON.stringify(event),
+        }).catch(() => { closed = true; });
+      });
+
+      // Keep the stream open until job completes or client disconnects
+      await new Promise<void>((resolve) => {
+        const checkInterval = setInterval(() => {
+          if (closed || ctx.output.jobCompleted) {
+            clearInterval(checkInterval);
+            unsubscribe();
+            resolve();
+          }
+        }, 500);
+      });
+    });
+  });
+
+  // List runs from DB
+  app.get("/api/runs", (c) => {
+    const db = getDb();
+    const allRuns = db.select().from(runs).orderBy(desc(runs.startedAt)).limit(50).all();
+    return c.json(allRuns);
+  });
+
+  // Get a single run with jobs, steps, and logs
+  app.get("/api/runs/:id", (c) => {
+    const runId = c.req.param("id");
+    const db = getDb();
+
+    const run = db.select().from(runs).where(eq(runs.id, runId)).get();
+    if (!run) return c.json({ error: "Run not found" }, 404);
+
+    const runJobs = db.select().from(jobs).where(eq(jobs.runId, runId)).all();
+    const allSteps: any[] = [];
+    const allLogs: any[] = [];
+    for (const j of runJobs) {
+      const js = db.select().from(steps).where(eq(steps.jobId, j.id)).all();
+      allSteps.push(...js);
+      for (const s of js) {
+        allLogs.push(...db.select().from(stepLogs).where(eq(stepLogs.stepId, s.id)).all());
+      }
+    }
+
+    return c.json({ run, jobs: runJobs, steps: allSteps, logs: allLogs });
+  });
+}

--- a/web/layout.ts
+++ b/web/layout.ts
@@ -1,0 +1,104 @@
+import { html } from "hono/html";
+import type { HtmlEscapedString } from "hono/utils/html";
+
+export function layout(title: string, content: HtmlEscapedString) {
+  return html`<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>${title} — localrunner</title>
+  <script src="https://unpkg.com/htmx.org@2.0.4"></script>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, monospace;
+      background: #0d1117;
+      color: #c9d1d9;
+      line-height: 1.5;
+    }
+    a { color: #58a6ff; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+
+    .container { max-width: 960px; margin: 0 auto; padding: 1rem; }
+
+    header {
+      border-bottom: 1px solid #21262d;
+      padding: 0.75rem 0;
+      margin-bottom: 1.5rem;
+    }
+    header .container { display: flex; align-items: center; gap: 1rem; }
+    header h1 { font-size: 1.1rem; font-weight: 600; }
+    header nav a { font-size: 0.9rem; color: #8b949e; }
+    header nav a:hover { color: #c9d1d9; }
+
+    .badge {
+      display: inline-block;
+      padding: 0.15rem 0.5rem;
+      border-radius: 12px;
+      font-size: 0.75rem;
+      font-weight: 600;
+    }
+    .badge-succeeded { background: #238636; color: #fff; }
+    .badge-failed { background: #da3633; color: #fff; }
+    .badge-cancelled { background: #6e7681; color: #fff; }
+    .badge-in_progress { background: #d29922; color: #fff; }
+    .badge-queued { background: #388bfd; color: #fff; }
+
+    table { width: 100%; border-collapse: collapse; }
+    th { text-align: left; font-size: 0.8rem; color: #8b949e; padding: 0.5rem; border-bottom: 1px solid #21262d; }
+    td { padding: 0.5rem; border-bottom: 1px solid #161b22; font-size: 0.9rem; }
+    tr:hover { background: #161b22; }
+
+    .run-detail { margin-top: 1rem; }
+    .run-header { margin-bottom: 1rem; }
+    .run-header h2 { font-size: 1.2rem; margin-bottom: 0.25rem; }
+    .run-meta { font-size: 0.85rem; color: #8b949e; }
+
+    .step { margin: 0.5rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid #21262d; }
+    .step-succeeded { border-color: #238636; }
+    .step-failed { border-color: #da3633; }
+    .step-in_progress { border-color: #d29922; }
+    .step-name { font-weight: 600; font-size: 0.9rem; }
+    .step-meta { font-size: 0.8rem; color: #8b949e; }
+
+    .logs {
+      margin-top: 1rem;
+      background: #161b22;
+      border: 1px solid #21262d;
+      border-radius: 6px;
+      padding: 0.75rem;
+      max-height: 600px;
+      overflow-y: auto;
+      font-family: "SF Mono", "Fira Code", monospace;
+      font-size: 0.8rem;
+      white-space: pre-wrap;
+      word-break: break-all;
+      line-height: 1.4;
+    }
+    .log-line { color: #c9d1d9; }
+
+    .empty { text-align: center; padding: 3rem; color: #8b949e; }
+
+    .refresh-indicator {
+      font-size: 0.75rem;
+      color: #484f58;
+      float: right;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="container">
+      <h1>localrunner</h1>
+      <nav>
+        <a href="/">Runs</a>
+      </nav>
+    </div>
+  </header>
+  <div class="container">
+    ${content}
+  </div>
+</body>
+</html>`;
+}

--- a/web/routes.ts
+++ b/web/routes.ts
@@ -1,0 +1,63 @@
+import type { Hono } from "hono";
+import { layout } from "./layout";
+import { runsPage, runsTable } from "./runs";
+import { runDetailPage, runDetailContent } from "./run-detail";
+import { getDb } from "../db";
+import { runs, jobs, steps, stepLogs } from "../db/schema";
+import { eq, desc } from "drizzle-orm";
+
+export function registerWebRoutes(app: Hono) {
+  // Dashboard — list of recent runs
+  app.get("/", (c) => {
+    const db = getDb();
+    const allRuns = db.select().from(runs).orderBy(desc(runs.startedAt)).limit(50).all();
+    return c.html(layout("Runs", runsPage(allRuns)));
+  });
+
+  // HTMX partial — refreshable runs table
+  app.get("/partials/runs", (c) => {
+    const db = getDb();
+    const allRuns = db.select().from(runs).orderBy(desc(runs.startedAt)).limit(50).all();
+    return c.html(runsTable(allRuns));
+  });
+
+  // Run detail page
+  app.get("/runs/:id", (c) => {
+    const runId = c.req.param("id");
+    const data = loadRunDetail(runId);
+    if (!data) return c.html(layout("Not Found", runsPage([])), 404);
+    return c.html(layout(
+      `${data.run.workflowName || "Run"} — ${data.run.jobName || ""}`,
+      runDetailPage(data.run, data.jobs, data.steps, data.logs),
+    ));
+  });
+
+  // HTMX partial — refreshable run detail
+  app.get("/partials/runs/:id", (c) => {
+    const runId = c.req.param("id");
+    const data = loadRunDetail(runId);
+    if (!data) return c.text("Not found", 404);
+    return c.html(runDetailContent(data.run, data.jobs, data.steps, data.logs));
+  });
+}
+
+function loadRunDetail(runId: string) {
+  const db = getDb();
+  const run = db.select().from(runs).where(eq(runs.id, runId)).get();
+  if (!run) return null;
+
+  const runJobs = db.select().from(jobs).where(eq(jobs.runId, runId)).all();
+  const allSteps: any[] = [];
+  const allLogs: any[] = [];
+
+  for (const job of runJobs) {
+    const jobSteps = db.select().from(steps).where(eq(steps.jobId, job.id)).all();
+    allSteps.push(...jobSteps);
+    for (const step of jobSteps) {
+      const logs = db.select().from(stepLogs).where(eq(stepLogs.stepId, step.id)).all();
+      allLogs.push(...logs);
+    }
+  }
+
+  return { run, jobs: runJobs, steps: allSteps, logs: allLogs };
+}

--- a/web/run-detail.ts
+++ b/web/run-detail.ts
@@ -1,0 +1,122 @@
+import { html } from "hono/html";
+
+interface Run {
+  id: string;
+  workflowName: string | null;
+  jobName: string | null;
+  eventName: string | null;
+  repoFullName: string | null;
+  sha: string | null;
+  ref: string | null;
+  status: string | null;
+  conclusion: string | null;
+  startedAt: number | null;
+  completedAt: number | null;
+}
+
+interface Job {
+  id: string;
+  name: string | null;
+  status: string | null;
+  conclusion: string | null;
+  startedAt: number | null;
+  completedAt: number | null;
+}
+
+interface Step {
+  id: number;
+  jobId: string | null;
+  name: string | null;
+  status: string | null;
+  conclusion: string | null;
+  sortOrder: number | null;
+  startedAt: number | null;
+  completedAt: number | null;
+}
+
+interface StepLog {
+  id: number;
+  stepId: number | null;
+  lineNumber: number | null;
+  content: string | null;
+}
+
+function badge(status: string | null, conclusion: string | null) {
+  if (status === "completed" && conclusion) {
+    return html`<span class="badge badge-${conclusion}">${conclusion}</span>`;
+  }
+  if (status) {
+    return html`<span class="badge badge-${status}">${status}</span>`;
+  }
+  return html`<span class="badge badge-queued">queued</span>`;
+}
+
+function duration(start: number | null, end: number | null): string {
+  if (!start) return "";
+  const elapsed = (end || Date.now()) - start;
+  if (elapsed < 1000) return "<1s";
+  if (elapsed < 60000) return `${Math.floor(elapsed / 1000)}s`;
+  return `${Math.floor(elapsed / 60000)}m ${Math.floor((elapsed % 60000) / 1000)}s`;
+}
+
+export function runDetailPage(run: Run, jobs: Job[], steps: Step[], logs: StepLog[]) {
+  const isActive = run.status === "in_progress" || run.status === "queued";
+  const pollAttr = isActive ? `hx-get="/partials/runs/${run.id}" hx-trigger="every 2s" hx-swap="innerHTML"` : "";
+
+  return html`
+    <div ${pollAttr}>
+      ${runDetailContent(run, jobs, steps, logs)}
+    </div>
+  `;
+}
+
+export function runDetailContent(run: Run, jobs: Job[], steps: Step[], logs: StepLog[]) {
+  const logsByStep = new Map<number, StepLog[]>();
+  for (const log of logs) {
+    if (log.stepId == null) continue;
+    const arr = logsByStep.get(log.stepId) || [];
+    arr.push(log);
+    logsByStep.set(log.stepId, arr);
+  }
+
+  return html`
+    <div class="run-header">
+      <h2>${run.workflowName || "Run"} — ${run.jobName || ""} ${badge(run.status, run.conclusion)}</h2>
+      <div class="run-meta">
+        ${run.eventName || ""} &middot;
+        ${run.repoFullName || ""} &middot;
+        <code>${run.sha?.slice(0, 8) || ""}</code> &middot;
+        ${duration(run.startedAt, run.completedAt)}
+      </div>
+    </div>
+
+    ${jobs.map((job) => {
+      const jobSteps = steps
+        .filter((s) => s.jobId === job.id)
+        .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0));
+
+      return html`
+        <div class="run-detail">
+          <h3>${job.name || "Job"} ${badge(job.status, job.conclusion)}</h3>
+
+          ${jobSteps.map((step) => {
+            const stepClass = step.conclusion || step.status || "";
+            const stepLogs = logsByStep.get(step.id) || [];
+            stepLogs.sort((a, b) => (a.lineNumber ?? 0) - (b.lineNumber ?? 0));
+
+            return html`
+              <div class="step step-${stepClass}">
+                <div class="step-name">${step.name || "Step"} ${badge(step.status, step.conclusion)}</div>
+                <div class="step-meta">${duration(step.startedAt, step.completedAt)}</div>
+                ${stepLogs.length > 0
+                  ? html`<div class="logs">${stepLogs.map((l) => html`<div class="log-line">${l.content || ""}</div>`)}</div>`
+                  : html``
+                }
+              </div>
+            `;
+          })}
+        </div>
+      `;
+    })}
+  `;
+}

--- a/web/runs.ts
+++ b/web/runs.ts
@@ -1,0 +1,91 @@
+import { html } from "hono/html";
+
+interface Run {
+  id: string;
+  workflowName: string | null;
+  jobName: string | null;
+  eventName: string | null;
+  repoFullName: string | null;
+  sha: string | null;
+  ref: string | null;
+  status: string | null;
+  conclusion: string | null;
+  startedAt: number | null;
+  completedAt: number | null;
+}
+
+function badge(status: string | null, conclusion: string | null) {
+  if (status === "completed" && conclusion) {
+    return html`<span class="badge badge-${conclusion}">${conclusion}</span>`;
+  }
+  if (status) {
+    return html`<span class="badge badge-${status}">${status}</span>`;
+  }
+  return html`<span class="badge badge-queued">queued</span>`;
+}
+
+function relativeTime(ts: number | null): string {
+  if (!ts) return "";
+  const diff = Date.now() - ts;
+  if (diff < 60000) return "just now";
+  if (diff < 3600000) return `${Math.floor(diff / 60000)}m ago`;
+  if (diff < 86400000) return `${Math.floor(diff / 3600000)}h ago`;
+  return new Date(ts).toLocaleDateString();
+}
+
+function duration(start: number | null, end: number | null): string {
+  if (!start) return "";
+  const elapsed = (end || Date.now()) - start;
+  if (elapsed < 1000) return "<1s";
+  if (elapsed < 60000) return `${Math.floor(elapsed / 1000)}s`;
+  return `${Math.floor(elapsed / 60000)}m ${Math.floor((elapsed % 60000) / 1000)}s`;
+}
+
+export function runsTable(runs: Run[]) {
+  if (runs.length === 0) {
+    return html`<div class="empty">No runs yet. Trigger one with <code>localrunner push</code></div>`;
+  }
+
+  return html`
+    <table>
+      <thead>
+        <tr>
+          <th>Status</th>
+          <th>Workflow</th>
+          <th>Job</th>
+          <th>Event</th>
+          <th>SHA</th>
+          <th>Duration</th>
+          <th>Started</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${runs.map(
+          (r) => html`
+            <tr>
+              <td>${badge(r.status, r.conclusion)}</td>
+              <td><a href="/runs/${r.id}">${r.workflowName || "—"}</a></td>
+              <td>${r.jobName || "—"}</td>
+              <td>${r.eventName || "—"}</td>
+              <td><code>${r.sha?.slice(0, 8) || "—"}</code></td>
+              <td>${duration(r.startedAt, r.completedAt)}</td>
+              <td>${relativeTime(r.startedAt)}</td>
+            </tr>
+          `,
+        )}
+      </tbody>
+    </table>
+  `;
+}
+
+export function runsPage(runs: Run[]) {
+  return html`
+    <div
+      hx-get="/partials/runs"
+      hx-trigger="every 3s"
+      hx-swap="innerHTML"
+    >
+      ${runsTable(runs)}
+    </div>
+  `;
+}


### PR DESCRIPTION
## Summary
- Migrate server from raw Bun.serve() routes to Hono framework for cleaner routing and middleware
- Add HTMX-based web dashboard for viewing runs, steps, and logs (dark theme, auto-refreshing)
- Add long-lived server mode (`bun cli.ts serve` / `bun serve.ts`) supporting multiple concurrent runs via JWT-based routing
- CLI auto-detects running server and delegates via SSE output streaming, falling back to ephemeral single-run mode

## Test plan
- [x] `bun test` — all 102 unit tests pass
- [ ] `bun cli.ts serve --port 9637` starts server, web UI accessible at `http://localhost:9637/`
- [ ] `bun cli.ts push` detects server, registers run, streams output to terminal
- [ ] Web UI shows runs, steps, and logs with auto-refresh
- [ ] Ephemeral mode (`bun cli.ts push` without server) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)