### PR TITLE
Replace HTMX polling with SSE pub/sub for live web UI

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -183,7 +183,7 @@ if (positionals[0] === "serve") {
   const runManager = new RunManager();
   const { app, addRunnerCatchAll } = createMultiRunApp(runManager);
 
-  registerWebRoutes(app);
+  registerWebRoutes(app, runManager);
   registerApiRoutes(app, runManager, port);
   addRunnerCatchAll();
 

--- a/serve.ts
+++ b/serve.ts
@@ -30,7 +30,7 @@ const runManager = new RunManager();
 const { app, addRunnerCatchAll } = createMultiRunApp(runManager);
 
 // Web UI and API routes (before runner catch-all)
-registerWebRoutes(app);
+registerWebRoutes(app, runManager);
 registerApiRoutes(app, runManager, port);
 
 // Runner protocol catch-all (must be last)

--- a/server/runs.ts
+++ b/server/runs.ts
@@ -1,6 +1,23 @@
 import { createRunContext } from "./types";
 import type { ServerConfig, RunContext } from "./types";
 
+type Listener = () => void;
+
+export class GlobalEventBus {
+  private subscribers = new Set<Listener>();
+
+  subscribe(fn: Listener): () => void {
+    this.subscribers.add(fn);
+    return () => this.subscribers.delete(fn);
+  }
+
+  emit(): void {
+    for (const fn of this.subscribers) {
+      fn();
+    }
+  }
+}
+
 /**
  * RunManager tracks active runs on the server.
  * Runs are identified by JWT token: the runner gets a JWT containing
@@ -9,10 +26,20 @@ import type { ServerConfig, RunContext } from "./types";
  */
 export class RunManager {
   private activeRuns = new Map<string, RunContext>();
+  public eventBus = new GlobalEventBus();
 
   registerRun(config: ServerConfig): { ctx: RunContext; jobCompleted: Promise<string> } {
     const { ctx, jobCompleted } = createRunContext(config);
     this.activeRuns.set(ctx.runId, ctx);
+
+    this.eventBus.emit();
+
+    ctx.output.subscribe((event) => {
+      if (event.type === "step_start" || event.type === "step_complete" || event.type === "job_complete") {
+        this.eventBus.emit();
+      }
+    });
+
     return { ctx, jobCompleted };
   }
 
@@ -40,6 +67,7 @@ export class RunManager {
 
   completeRun(runId: string) {
     this.activeRuns.delete(runId);
+    this.eventBus.emit();
   }
 
   getActiveRuns(): RunContext[] {

--- a/web/layout.ts
+++ b/web/layout.ts
@@ -9,6 +9,7 @@ export function layout(title: string, content: HtmlEscapedString) {
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>${title} — localrunner</title>
   <script src="https://unpkg.com/htmx.org@2.0.4"></script>
+  <script src="https://unpkg.com/htmx-ext-sse@2.2.2/sse.js"></script>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     body {

--- a/web/routes.ts
+++ b/web/routes.ts
@@ -1,12 +1,14 @@
 import type { Hono } from "hono";
+import { streamSSE } from "hono/streaming";
 import { layout } from "./layout";
 import { runsPage, runsTable } from "./runs";
 import { runDetailPage, runDetailContent } from "./run-detail";
 import { getDb } from "../db";
 import { runs, jobs, steps, stepLogs } from "../db/schema";
 import { eq, desc } from "drizzle-orm";
+import type { RunManager } from "../server/runs";
 
-export function registerWebRoutes(app: Hono) {
+export function registerWebRoutes(app: Hono, runManager: RunManager) {
   // Dashboard — list of recent runs
   app.get("/", (c) => {
     const db = getDb();
@@ -38,6 +40,68 @@ export function registerWebRoutes(app: Hono) {
     const data = loadRunDetail(runId);
     if (!data) return c.text("Not found", 404);
     return c.html(runDetailContent(data.run, data.jobs, data.steps, data.logs));
+  });
+
+  // SSE stream for the runs list page — notifies when any run changes
+  app.get("/sse/runs", (c) => {
+    return streamSSE(c, async (stream) => {
+      let closed = false;
+      stream.onAbort(() => { closed = true; });
+
+      const unsubscribe = runManager.eventBus.subscribe(() => {
+        if (closed) return;
+        stream.writeSSE({ event: "run_changed", data: "" }).catch(() => { closed = true; });
+      });
+
+      const keepalive = setInterval(() => {
+        if (closed) { clearInterval(keepalive); return; }
+        stream.writeSSE({ event: "keepalive", data: "" }).catch(() => { closed = true; });
+      }, 30000);
+
+      await new Promise<void>((resolve) => {
+        const check = setInterval(() => {
+          if (closed) { clearInterval(check); clearInterval(keepalive); unsubscribe(); resolve(); }
+        }, 1000);
+      });
+    });
+  });
+
+  // SSE stream for a single run — notifies on step/log/job changes
+  app.get("/sse/runs/:id", (c) => {
+    const runId = c.req.param("id");
+    const ctx = runManager.getRunByRunId(runId);
+
+    if (!ctx) {
+      return streamSSE(c, async (stream) => {
+        await stream.writeSSE({ event: "run_complete", data: "" });
+      });
+    }
+
+    return streamSSE(c, async (stream) => {
+      let closed = false;
+      stream.onAbort(() => { closed = true; });
+
+      const unsubscribe = ctx.output.subscribe((event) => {
+        if (closed) return;
+        if (event.type === "step_start" || event.type === "step_complete" ||
+            event.type === "step_log" || event.type === "job_complete") {
+          stream.writeSSE({ event: "run_changed", data: "" }).catch(() => { closed = true; });
+        }
+      });
+
+      const keepalive = setInterval(() => {
+        if (closed) { clearInterval(keepalive); return; }
+        stream.writeSSE({ event: "keepalive", data: "" }).catch(() => { closed = true; });
+      }, 30000);
+
+      await new Promise<void>((resolve) => {
+        const check = setInterval(() => {
+          if (closed || ctx.output.jobCompleted) {
+            clearInterval(check); clearInterval(keepalive); unsubscribe(); resolve();
+          }
+        }, 1000);
+      });
+    });
   });
 }
 

--- a/web/run-detail.ts
+++ b/web/run-detail.ts
@@ -61,10 +61,19 @@ function duration(start: number | null, end: number | null): string {
 
 export function runDetailPage(run: Run, jobs: Job[], steps: Step[], logs: StepLog[]) {
   const isActive = run.status === "in_progress" || run.status === "queued";
-  const pollAttr = isActive ? `hx-get="/partials/runs/${run.id}" hx-trigger="every 2s" hx-swap="innerHTML"` : "";
+
+  if (!isActive) {
+    return html`<div>${runDetailContent(run, jobs, steps, logs)}</div>`;
+  }
 
   return html`
-    <div ${pollAttr}>
+    <div
+      hx-ext="sse"
+      sse-connect="/sse/runs/${run.id}"
+      hx-get="/partials/runs/${run.id}"
+      hx-trigger="sse:run_changed"
+      hx-swap="innerHTML"
+    >
       ${runDetailContent(run, jobs, steps, logs)}
     </div>
   `;

--- a/web/runs.ts
+++ b/web/runs.ts
@@ -81,8 +81,10 @@ export function runsTable(runs: Run[]) {
 export function runsPage(runs: Run[]) {
   return html`
     <div
+      hx-ext="sse"
+      sse-connect="/sse/runs"
       hx-get="/partials/runs"
-      hx-trigger="every 3s"
+      hx-trigger="sse:run_changed"
       hx-swap="innerHTML"
     >
       ${runsTable(runs)}


### PR DESCRIPTION
## Summary
- Add `GlobalEventBus` to `RunManager` that emits on run register/complete and forwards state-changing events (`step_start`, `step_complete`, `job_complete`) from each run's `OutputHandler`
- Add SSE endpoints (`/sse/runs` for the runs list, `/sse/runs/:id` for individual run detail) using Hono's `streamSSE`
- Replace HTMX `hx-trigger="every Ns"` polling with the HTMX SSE extension (`sse-connect` + `hx-trigger="sse:run_changed"`) so pages update instantly on state changes

## Test plan
- [x] `bun test` passes (102 tests)
- [ ] Start server with `bun serve.ts`, open http://localhost:9637/, verify `/sse/runs` EventSource in Network tab
- [ ] Run `bun cli.ts push` — runs page should update live without polling
- [ ] Click into a run detail — verify `/sse/runs/:id` connection and live step/log updates
- [ ] After run completes, SSE stream closes and page is static

🤖 Generated with [Claude Code](https://claude.com/claude-code)