### PR TITLE
Use consistent UUIDs for all IDs

### DIFF
--- a/db/schema.ts
+++ b/db/schema.ts
@@ -30,7 +30,7 @@ export const jobs = sqliteTable("jobs", {
 });
 
 export const steps = sqliteTable("steps", {
-  id: integer("id").primaryKey({ autoIncrement: true }),
+  id: text("id").primaryKey(),
   jobId: text("job_id")
     .notNull()
     .references(() => jobs.id),
@@ -44,7 +44,7 @@ export const steps = sqliteTable("steps", {
 
 export const stepLogs = sqliteTable("step_logs", {
   id: integer("id").primaryKey({ autoIncrement: true }),
-  stepId: integer("step_id")
+  stepId: text("step_id")
     .notNull()
     .references(() => steps.id),
   lineNumber: integer("line_number").notNull(),

--- a/output.ts
+++ b/output.ts
@@ -1,6 +1,7 @@
+import { randomUUID } from "crypto";
 import { getDb } from "./db";
 import { runs, jobs, steps as stepsTable, stepLogs } from "./db/schema";
-import { eq, isNull } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 
 export type OutputMode = "pretty" | "raw" | "verbose";
 
@@ -30,15 +31,25 @@ export class OutputHandler {
   runId: string | null = null;
   jobId: string | null = null;
   jobCompleted = false;
-  private stepDbIds: Map<string, number> = new Map();
+  private stepUuids: Map<string, string> = new Map();
   private stepSortOrder = 0;
-  private pendingLogs: Map<string, { stepId: number; lines: string[] }> = new Map();
+  private pendingLogs: Map<string, { stepId: string; lines: string[] }> = new Map();
 
   /** External subscribers for event streaming (e.g. SSE) */
   private subscribers: Set<(event: RunEvent) => void> = new Set();
 
   constructor(mode: OutputMode) {
     this.mode = mode;
+  }
+
+  /** Build name→UUID mapping from the step objects sent to the runner. */
+  setStepMapping(jobSteps: object[]): void {
+    for (const step of jobSteps) {
+      const s = step as { id?: string; displayName?: string };
+      if (s.id && s.displayName) {
+        this.stepUuids.set(s.displayName, s.id);
+      }
+    }
   }
 
   subscribe(fn: (event: RunEvent) => void): () => void {
@@ -209,19 +220,19 @@ export class OutputHandler {
       try {
         const db = getDb();
         const order = this.stepSortOrder++;
-        const result = db
-          .insert(stepsTable)
+        const stepId = this.stepUuids.get(name) || randomUUID();
+        db.insert(stepsTable)
           .values({
+            id: stepId,
             jobId: this.jobId,
             name,
             status: "in_progress",
             startedAt: timestamp,
             sortOrder: order,
           })
-          .returning({ id: stepsTable.id })
-          .get();
-        this.stepDbIds.set(name, result.id);
-        this.pendingLogs.set(name, { stepId: result.id, lines: [] });
+          .run();
+        this.stepUuids.set(name, stepId);
+        this.pendingLogs.set(name, { stepId, lines: [] });
       } catch {}
     }
   }
@@ -239,12 +250,12 @@ export class OutputHandler {
 
     if (this.jobId) {
       try {
-        const stepDbId = this.stepDbIds.get(name);
-        if (stepDbId) {
+        const stepId = this.stepUuids.get(name);
+        if (stepId) {
           const db = getDb();
           db.update(stepsTable)
             .set({ status: "completed", conclusion, completedAt: timestamp })
-            .where(eq(stepsTable.id, stepDbId))
+            .where(eq(stepsTable.id, stepId))
             .run();
           this.flushStepLogs(name);
         }
@@ -300,11 +311,11 @@ export class OutputHandler {
       // Mark incomplete steps as cancelled
       for (const [name, step] of this.steps) {
         if (!step.completedAt) {
-          const stepDbId = this.stepDbIds.get(name);
-          if (stepDbId) {
+          const stepId = this.stepUuids.get(name);
+          if (stepId) {
             db.update(stepsTable)
               .set({ status: "completed", conclusion: "cancelled", completedAt: now })
-              .where(eq(stepsTable.id, stepDbId))
+              .where(eq(stepsTable.id, stepId))
               .run();
           }
         }

--- a/server/types.ts
+++ b/server/types.ts
@@ -70,7 +70,7 @@ export function createRunContext(config: ServerConfig): { ctx: RunContext; jobCo
     resolveJobCompleted = resolve;
   });
 
-  const runId = Date.now().toString();
+  const runId = randomUUID();
   const jobId = randomUUID();
 
   const ctx: RunContext = {
@@ -104,6 +104,7 @@ export function createRunContext(config: ServerConfig): { ctx: RunContext; jobCo
 
   output.runId = runId;
   output.jobId = jobId;
+  output.setStepMapping(config.jobSteps);
 
   try {
     const db = getDb();


### PR DESCRIPTION
## Summary
- Switch `runId` from `Date.now()` timestamp string to `randomUUID()` for consistency with all other IDs
- Change `steps.id` from auto-increment integer to text UUID, using the same UUID already generated for the runner protocol
- Change `stepLogs.stepId` from integer to text to match
- Add `setStepMapping()` on `OutputHandler` so it receives the step displayName→UUID mapping from the runner's job steps, ensuring the same UUID flows from runner protocol through to the database

Closes #35

## Test plan
- [x] All 102 unit tests pass
- [ ] Run a workflow end-to-end and verify run/job/step IDs are all UUIDs in the web UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)