### PR TITLE
Auto-detect runner context (OS, arch, temp)

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -12,6 +12,7 @@ import { resolveVariables } from "./variables";
 import { existsSync } from "fs";
 import { OutputHandler, type OutputMode } from "./output";
 import { expandMatrix, filterMatrix, formatMatrixCombo } from "./matrix";
+import { detectOs, detectArch } from "./platform";
 
 const { values, positionals } = parseArgs({
   args: Bun.argv.slice(2),
@@ -486,7 +487,10 @@ async function main() {
       }
 
       // Build expression context and convert steps
-      const exprCtx = buildExpressionContext(repoCtx, eventName, eventPayload, workflowName, selectedJobName, undefined, secrets, variables, hasMatrix ? matrixCombo : undefined);
+      const isDocker = !!dockerImage;
+      const runnerOs = isDocker ? "Linux" : detectOs();
+      const runnerArch = isDocker ? "X64" : detectArch();
+      const exprCtx = buildExpressionContext(repoCtx, eventName, eventPayload, workflowName, selectedJobName, undefined, secrets, variables, hasMatrix ? matrixCombo : undefined, { os: runnerOs, arch: runnerArch });
 
       const jobSteps = workflowStepsToRunnerSteps(
         selectedJob.steps,

--- a/expressions.test.ts
+++ b/expressions.test.ts
@@ -1,6 +1,7 @@
 import { test, expect, describe } from "bun:test";
 import { evaluateExpressions, buildExpressionContext } from "./expressions";
 import type { RepoContext } from "./context";
+import { detectOs, detectArch } from "./platform";
 
 // Helper to build expression strings without triggering JS template parsing
 function expr(name: string): string {
@@ -188,12 +189,18 @@ describe("buildExpressionContext", () => {
     expect(ctx["github.ref_name"]).toBe("v1.0.0");
   });
 
-  test("populates runner context", () => {
+  test("populates runner context with detected values", () => {
     const ctx = buildExpressionContext(mockCtx, "push", {}, "wf", "job");
-    expect(ctx["runner.os"]).toBe("macOS");
-    expect(ctx["runner.arch"]).toBe("ARM64");
+    expect(ctx["runner.os"]).toBe(detectOs());
+    expect(ctx["runner.arch"]).toBe(detectArch());
     expect(ctx["runner.name"]).toBe("local-runner");
     expect(ctx["runner.temp"]).toBe("/tmp");
+  });
+
+  test("populates runner context with explicit values", () => {
+    const ctx = buildExpressionContext(mockCtx, "push", {}, "wf", "job", undefined, undefined, undefined, undefined, { os: "Linux", arch: "X64" });
+    expect(ctx["runner.os"]).toBe("Linux");
+    expect(ctx["runner.arch"]).toBe("X64");
   });
 
   test("flattens event payload into github.event.*", () => {
@@ -391,7 +398,7 @@ describe("expression evaluation integration", () => {
     });
     const input =
       "node " + expr("env.NODE_VERSION") + " on " + expr("runner.os");
-    expect(evaluateExpressions(input, ctx)).toBe("node 20 on macOS");
+    expect(evaluateExpressions(input, ctx)).toBe(`node 20 on ${detectOs()}`);
   });
 
   test("evaluates secrets expressions", () => {

--- a/expressions.ts
+++ b/expressions.ts
@@ -1,4 +1,5 @@
 import type { RepoContext } from "./context";
+import { detectOs, detectArch } from "./platform";
 
 // Build a flat lookup table for ${{ expr }} evaluation
 export function buildExpressionContext(
@@ -11,6 +12,7 @@ export function buildExpressionContext(
   secrets?: Record<string, string>,
   variables?: Record<string, string>,
   matrix?: Record<string, string>,
+  runnerInfo?: { os: string; arch: string },
 ): Record<string, string> {
   const ctx: Record<string, string> = {};
 
@@ -46,10 +48,12 @@ export function buildExpressionContext(
   ctx["github.retention_days"] = "90";
 
   // runner context
-  ctx["runner.os"] = "macOS";
-  ctx["runner.arch"] = "ARM64";
+  const runnerOs = runnerInfo?.os ?? detectOs();
+  const runnerArch = runnerInfo?.arch ?? detectArch();
+  ctx["runner.os"] = runnerOs;
+  ctx["runner.arch"] = runnerArch;
   ctx["runner.name"] = "local-runner";
-  ctx["runner.temp"] = "/tmp";
+  ctx["runner.temp"] = runnerOs === "Windows" ? (process.env["TEMP"] || "C:\\Windows\\Temp") : "/tmp";
   ctx["runner.tool_cache"] = "";
   ctx["runner.workspace"] = "";
   ctx["runner.debug"] = "";

--- a/orchestrator.ts
+++ b/orchestrator.ts
@@ -5,6 +5,7 @@ import type { Service } from "./workflow";
 import { OutputHandler } from "./output";
 import type { RunContext } from "./server/types";
 import type { RunManager } from "./server/runs";
+import { detectOs, detectArch } from "./platform";
 
 export interface RunConfig {
   port: number;
@@ -301,8 +302,8 @@ export async function startRun(config: RunConfig): Promise<RunResult> {
     variables,
     matrix,
     hostAddress,
-    runnerOs: isDocker ? "Linux" : "macOS",
-    runnerArch: isDocker ? "X64" : "ARM64",
+    runnerOs: isDocker ? "Linux" : detectOs(),
+    runnerArch: isDocker ? "X64" : detectArch(),
     output: configOutput,
   });
 
@@ -383,8 +384,8 @@ export async function startRunOnRemoteServer(config: RunConfig): Promise<RunResu
         variables,
         matrix,
         hostAddress,
-        runnerOs: isDocker ? "Linux" : "macOS",
-        runnerArch: isDocker ? "X64" : "ARM64",
+        runnerOs: isDocker ? "Linux" : detectOs(),
+        runnerArch: isDocker ? "X64" : detectArch(),
       },
     }),
   });

--- a/platform.ts
+++ b/platform.ts
@@ -1,0 +1,35 @@
+/**
+ * Detect the runner OS in GitHub Actions format.
+ * Returns "macOS", "Linux", or "Windows".
+ */
+export function detectOs(): string {
+  switch (process.platform) {
+    case "darwin":
+      return "macOS";
+    case "linux":
+      return "Linux";
+    case "win32":
+      return "Windows";
+    default:
+      return "Linux";
+  }
+}
+
+/**
+ * Detect the runner architecture in GitHub Actions format.
+ * Returns "X64", "ARM64", "ARM", or "X86".
+ */
+export function detectArch(): string {
+  switch (process.arch) {
+    case "x64":
+      return "X64";
+    case "arm64":
+      return "ARM64";
+    case "arm":
+      return "ARM";
+    case "ia32":
+      return "X86";
+    default:
+      return "X64";
+  }
+}

--- a/server/job.ts
+++ b/server/job.ts
@@ -141,7 +141,7 @@ function buildJobMessage(ctx: RunContext): object {
           { k: "arch", v: ctx.runnerArch },
           { k: "name", v: "local-runner" },
           { k: "tool_cache", v: "" },
-          { k: "temp", v: "/tmp" },
+          { k: "temp", v: ctx.runnerOs === "Windows" ? (process.env["TEMP"] || "C:\\Windows\\Temp") : "/tmp" },
           { k: "workspace", v: "" },
           { k: "debug", v: "" },
         ],

--- a/server/types.ts
+++ b/server/types.ts
@@ -3,6 +3,7 @@ import type { RepoContext } from "../context";
 import { OutputHandler } from "../output";
 import { getDb } from "../db";
 import { runs, jobs } from "../db/schema";
+import { detectOs, detectArch } from "../platform";
 
 export interface ServerConfig {
   port: number;
@@ -86,8 +87,8 @@ export function createRunContext(config: ServerConfig): { ctx: RunContext; jobCo
     matrix: config.matrix || {},
     hostAddress,
     serverBaseUrl,
-    runnerOs: config.runnerOs || "macOS",
-    runnerArch: config.runnerArch || "ARM64",
+    runnerOs: config.runnerOs || detectOs(),
+    runnerArch: config.runnerArch || detectArch(),
     output,
 
     runId: runId,


### PR DESCRIPTION
## Summary
- Adds `platform.ts` with `detectOs()` and `detectArch()` helpers that map `process.platform`/`process.arch` to GitHub Actions format
- Replaces all hardcoded `"macOS"`/`"ARM64"` with auto-detection for local runs, `"Linux"`/`"X64"` for Docker
- Wires platform-aware `runner.temp` in both expression context and server job messages

Closes #5

## Test plan
- [x] All 103 unit tests pass
- [x] Verified `detectOs()`/`detectArch()` returns correct values on macOS ARM64

🤖 Generated with [Claude Code](https://claude.com/claude-code)