### PR TITLE
Support step-level if conditions, continue-on-error, and env vars

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -492,14 +492,23 @@ async function main() {
       const runnerArch = isDocker ? "X64" : detectArch();
       const exprCtx = buildExpressionContext(repoCtx, eventName, eventPayload, workflowName, selectedJobName, undefined, secrets, variables, hasMatrix ? matrixCombo : undefined, { os: runnerOs, arch: runnerArch });
 
+      const evaluateOpts = (opts?: { condition?: string; continueOnError?: boolean; environment?: Record<string, string> }) => {
+        if (!opts) return opts;
+        return {
+          ...opts,
+          environment: opts.environment
+            ? Object.fromEntries(Object.entries(opts.environment).map(([k, v]) => [k, evaluateExpressions(v, exprCtx)]))
+            : undefined,
+        };
+      };
       const jobSteps = workflowStepsToRunnerSteps(
         selectedJob.steps,
-        (script, displayName) => scriptStep(evaluateExpressions(script, exprCtx), displayName),
-        (action, ref, displayName, inputs) => {
+        (script, displayName, opts) => scriptStep(evaluateExpressions(script, exprCtx), displayName, evaluateOpts(opts)),
+        (action, ref, displayName, inputs, opts) => {
           const evaluated = inputs
             ? Object.fromEntries(Object.entries(inputs).map(([k, v]) => [k, evaluateExpressions(v, exprCtx)]))
             : undefined;
-          return actionStep(action, ref, displayName, evaluated);
+          return actionStep(action, ref, displayName, evaluated, evaluateOpts(opts));
         },
       );
       const serviceNames = selectedJob.services ? Object.keys(selectedJob.services) : [];

--- a/context.ts
+++ b/context.ts
@@ -93,6 +93,7 @@ export function buildGitHubContextData(
   workflowName: string = "Local Workflow",
   jobName: string = "local_job",
   runId: string = "1",
+  workspace: string = "",
 ): object {
   const headRef = eventName === "pull_request"
     ? (eventPayload as any)?.pull_request?.head?.ref || ""
@@ -121,7 +122,7 @@ export function buildGitHubContextData(
       { k: "server_url", v: ctx.serverUrl },
       { k: "api_url", v: ctx.apiUrl },
       { k: "graphql_url", v: ctx.graphqlUrl },
-      { k: "workspace", v: "" },
+      { k: "workspace", v: workspace },
       { k: "action", v: "" },
       { k: "token", v: ctx.token },
       { k: "repositoryUrl", v: `${ctx.serverUrl}/${ctx.fullName}` },

--- a/server/job.ts
+++ b/server/job.ts
@@ -73,6 +73,12 @@ export function registerJobRoutes(app: Hono<ServerEnv>, ctx: RunContext) {
 }
 
 function buildJobMessage(ctx: RunContext): object {
+  // Compute the runner workspace path
+  // Docker runners use host.docker.internal and run from /home/runner
+  const isDocker = ctx.hostAddress === "host.docker.internal";
+  const workspace = isDocker
+    ? `/home/runner/_work/${ctx.repoCtx.repo}/${ctx.repoCtx.repo}`
+    : "";
   return {
     messageType: "RunnerJobRequest",
     plan: {
@@ -127,7 +133,7 @@ function buildJobMessage(ctx: RunContext): object {
       ],
     },
     contextData: {
-      github: buildGitHubContextData(ctx.repoCtx, ctx.eventName, ctx.eventPayload, ctx.workflowName, ctx.jobName, ctx.runId),
+      github: buildGitHubContextData(ctx.repoCtx, ctx.eventName, ctx.eventPayload, ctx.workflowName, ctx.jobName, ctx.runId, workspace),
       strategy: { t: 2, d: [] },
       matrix: {
         t: 2,
@@ -142,13 +148,15 @@ function buildJobMessage(ctx: RunContext): object {
           { k: "name", v: "local-runner" },
           { k: "tool_cache", v: "" },
           { k: "temp", v: ctx.runnerOs === "Windows" ? (process.env["TEMP"] || "C:\\Windows\\Temp") : "/tmp" },
-          { k: "workspace", v: "" },
+          { k: "workspace", v: workspace },
           { k: "debug", v: "" },
         ],
       },
     },
     variables: {
       "system.culture": { value: "en-US" },
+      "system.defaultWorkingDirectory": { value: workspace },
+      "system.github.workspace": { value: workspace },
       "system.github.token": { value: ctx.repoCtx.token, isSecret: true },
       "system.github.job": { value: ctx.jobName.replace(/[^a-zA-Z0-9_]/g, "_") },
       "system.github.launch_endpoint": {

--- a/server/steps.ts
+++ b/server/steps.ts
@@ -1,8 +1,23 @@
 import { randomUUID } from "crypto";
 
+export interface StepOptions {
+  condition?: string;
+  continueOnError?: boolean;
+  environment?: Record<string, string>;
+}
+
+// If condition contains a status function, use as-is; otherwise wrap with success()
+function resolveCondition(ifExpr?: string): string {
+  if (!ifExpr) return "success()";
+  const statusFunctions = /\b(success|failure|always|cancelled)\s*\(/;
+  if (statusFunctions.test(ifExpr)) return ifExpr;
+  return `success() && (${ifExpr})`;
+}
+
 export function scriptStep(
   script: string,
   displayName?: string,
+  opts?: StepOptions,
 ): object {
   return {
     type: "Action",
@@ -11,7 +26,11 @@ export function scriptStep(
     name: "__run",
     displayName: displayName || `Run ${script.slice(0, 40)}`,
     contextName: `run_${randomUUID().slice(0, 8)}`,
-    condition: "success()",
+    condition: resolveCondition(opts?.condition),
+    continueOnError: opts?.continueOnError ?? false,
+    environment: opts?.environment
+      ? { type: 2, map: Object.entries(opts.environment).map(([k, v]) => ({ Key: k, Value: v })) }
+      : { type: 2, map: [] },
     inputs: {
       type: 2,
       map: [{ Key: "script", Value: script }],
@@ -24,6 +43,7 @@ export function actionStep(
   ref: string,
   displayName?: string,
   inputs?: Record<string, string>,
+  opts?: StepOptions,
 ): object {
   const inputMap = inputs
     ? Object.entries(inputs).map(([k, v]) => ({ Key: k, Value: v }))
@@ -50,7 +70,11 @@ export function actionStep(
     name: action,
     displayName: displayName || `Run ${action}@${ref}`,
     contextName: action.replace(/[^a-zA-Z0-9]/g, "_"),
-    condition: "success()",
+    condition: resolveCondition(opts?.condition),
+    continueOnError: opts?.continueOnError ?? false,
+    environment: opts?.environment
+      ? { type: 2, map: Object.entries(opts.environment).map(([k, v]) => ({ Key: k, Value: v })) }
+      : { type: 2, map: [] },
     inputs: {
       type: 2,
       map: inputMap,

--- a/workflow.ts
+++ b/workflow.ts
@@ -141,10 +141,16 @@ export function matchesEvent(workflow: Workflow, eventName: string): boolean {
 
 export function workflowStepsToRunnerSteps(
   steps: Step[],
-  scriptStep: (script: string, displayName?: string) => object,
-  actionStep: (action: string, ref: string, displayName?: string, inputs?: Record<string, string>) => object,
+  scriptStep: (script: string, displayName?: string, opts?: { condition?: string; continueOnError?: boolean; environment?: Record<string, string> }) => object,
+  actionStep: (action: string, ref: string, displayName?: string, inputs?: Record<string, string>, opts?: { condition?: string; continueOnError?: boolean; environment?: Record<string, string> }) => object,
 ): object[] {
   return steps.map((step) => {
+    const opts = {
+      condition: step.if,
+      continueOnError: step["continue-on-error"] === true || step["continue-on-error"] === "true",
+      environment: step.env,
+    };
+
     if (step.uses) {
       // Parse action reference: owner/repo@ref or owner/repo/path@ref
       const atIndex = step.uses.lastIndexOf("@");
@@ -161,11 +167,11 @@ export function workflowStepsToRunnerSteps(
           )
         : undefined;
 
-      return actionStep(actionPath, ref, step.name, inputs);
+      return actionStep(actionPath, ref, step.name, inputs, opts);
     }
 
     if (step.run) {
-      return scriptStep(step.run, step.name);
+      return scriptStep(step.run, step.name, opts);
     }
 
     throw new Error(`Step must have either 'uses' or 'run': ${JSON.stringify(step)}`);


### PR DESCRIPTION
## Summary
- Pass workflow `if` conditions through to the runner with proper status function wrapping (`success() && (expr)` for conditions without status functions, raw expression for conditions with `always()`, `failure()`, etc.)
- Support `continue-on-error` on steps so execution continues after failures
- Support step-level `env` blocks with expression evaluation, using the runner protocol's `{type, map}` format
- Compute workspace path for Docker runners and pass it in contextData and system variables

## Test plan
- [x] `if: github.event_name == 'push'` correctly runs on push events
- [x] `if: github.event_name == 'pull_request'` correctly skips on push events
- [x] `if: always()` runs after failures
- [x] `if: failure()` skips when previous steps succeed
- [x] `continue-on-error: true` allows subsequent steps to run after failure
- [x] Step-level `env` with literal values and `${{ }}` expressions works
- [x] All 103 unit tests pass
- [x] Runner context (os, arch, temp) evaluates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)