### PR TITLE
Redesign web UI with sidebar layout, collapsible steps, and workflows page

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -183,7 +183,7 @@ if (positionals[0] === "serve") {
   const runManager = new RunManager();
   const { app, addRunnerCatchAll } = createMultiRunApp(runManager);
 
-  registerWebRoutes(app, runManager);
+  registerWebRoutes(app, runManager, port);
   registerApiRoutes(app, runManager, port);
   addRunnerCatchAll();
 

--- a/db/migrations/0001_steps_text_id.sql
+++ b/db/migrations/0001_steps_text_id.sql
@@ -1,0 +1,34 @@
+-- Migrate steps.id from integer to text (for UUID support)
+-- and step_logs.step_id from integer to text to match.
+
+CREATE TABLE `steps_new` (
+	`id` text PRIMARY KEY NOT NULL,
+	`job_id` text NOT NULL,
+	`name` text NOT NULL,
+	`status` text DEFAULT 'queued' NOT NULL,
+	`conclusion` text,
+	`started_at` integer,
+	`completed_at` integer,
+	`sort_order` integer NOT NULL,
+	FOREIGN KEY (`job_id`) REFERENCES `jobs`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+INSERT INTO `steps_new` SELECT CAST(`id` AS text), `job_id`, `name`, `status`, `conclusion`, `started_at`, `completed_at`, `sort_order` FROM `steps`;
+--> statement-breakpoint
+DROP TABLE `steps`;
+--> statement-breakpoint
+ALTER TABLE `steps_new` RENAME TO `steps`;
+--> statement-breakpoint
+CREATE TABLE `step_logs_new` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`step_id` text NOT NULL,
+	`line_number` integer NOT NULL,
+	`content` text NOT NULL,
+	FOREIGN KEY (`step_id`) REFERENCES `steps`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+INSERT INTO `step_logs_new` SELECT `id`, CAST(`step_id` AS text), `line_number`, `content` FROM `step_logs`;
+--> statement-breakpoint
+DROP TABLE `step_logs`;
+--> statement-breakpoint
+ALTER TABLE `step_logs_new` RENAME TO `step_logs`;

--- a/db/migrations/meta/0001_snapshot.json
+++ b/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,402 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "prevId": "04370713-8878-4442-abce-4d7dee93d329",
+  "tables": {
+    "artifacts": {
+      "name": "artifacts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "finalized": {
+          "name": "finalized",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "artifacts_run_id_runs_id_fk": {
+          "name": "artifacts_run_id_runs_id_fk",
+          "tableFrom": "artifacts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "jobs": {
+      "name": "jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "conclusion": {
+          "name": "conclusion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "jobs_run_id_runs_id_fk": {
+          "name": "jobs_run_id_runs_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "runs": {
+      "name": "runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_payload": {
+          "name": "event_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha": {
+          "name": "sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "conclusion": {
+          "name": "conclusion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "step_logs": {
+      "name": "step_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "line_number": {
+          "name": "line_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "step_logs_step_id_steps_id_fk": {
+          "name": "step_logs_step_id_steps_id_fk",
+          "tableFrom": "step_logs",
+          "tableTo": "steps",
+          "columnsFrom": [
+            "step_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "steps": {
+      "name": "steps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "conclusion": {
+          "name": "conclusion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "steps_job_id_jobs_id_fk": {
+          "name": "steps_job_id_jobs_id_fk",
+          "tableFrom": "steps",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1774553764158,
       "tag": "0000_secret_blue_marvel",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1774600000000,
+      "tag": "0001_steps_text_id",
+      "breakpoints": true
     }
   ]
 }

--- a/serve.ts
+++ b/serve.ts
@@ -30,7 +30,7 @@ const runManager = new RunManager();
 const { app, addRunnerCatchAll } = createMultiRunApp(runManager);
 
 // Web UI and API routes (before runner catch-all)
-registerWebRoutes(app, runManager);
+registerWebRoutes(app, runManager, port);
 registerApiRoutes(app, runManager, port);
 
 // Runner protocol catch-all (must be last)

--- a/web/layout.ts
+++ b/web/layout.ts
@@ -21,7 +21,62 @@ export function layout(title: string, content: HtmlEscapedString) {
     a { color: #58a6ff; text-decoration: none; }
     a:hover { text-decoration: underline; }
 
-    .container { max-width: 960px; margin: 0 auto; padding: 1rem; }
+    .container { max-width: 1200px; margin: 0 auto; padding: 1rem; }
+
+    .run-layout { display: flex; gap: 1.5rem; }
+    .run-sidebar {
+      width: 260px;
+      flex-shrink: 0;
+      position: sticky;
+      top: 1rem;
+      align-self: flex-start;
+      max-height: calc(100vh - 2rem);
+      overflow-y: auto;
+      border-right: 1px solid #21262d;
+      padding-right: 1rem;
+      background: #0d1117;
+    }
+    .run-main { flex: 1; min-width: 0; }
+
+    .sidebar-section { margin-bottom: 1.5rem; }
+    .sidebar-section h4 {
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: #8b949e;
+      margin-bottom: 0.5rem;
+      padding: 0 0.5rem;
+    }
+    .sidebar-job {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.4rem 0.5rem;
+      border-radius: 6px;
+      font-size: 0.85rem;
+      color: #c9d1d9;
+      cursor: pointer;
+      transition: background 0.15s;
+    }
+    .sidebar-job:hover { background: #161b22; text-decoration: none; }
+    .sidebar-job .status-dot {
+      width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0;
+    }
+    .dot-succeeded { background: #238636; }
+    .dot-failed { background: #da3633; }
+    .dot-cancelled { background: #6e7681; }
+    .dot-in_progress { background: #d29922; }
+    .dot-queued { background: #388bfd; }
+
+    .sidebar-artifact {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.3rem 0.5rem;
+      font-size: 0.8rem;
+      color: #8b949e;
+    }
+    .sidebar-artifact .artifact-size { margin-left: auto; font-size: 0.7rem; }
 
     header {
       border-bottom: 1px solid #21262d;
@@ -56,18 +111,36 @@ export function layout(title: string, content: HtmlEscapedString) {
     .run-header h2 { font-size: 1.2rem; margin-bottom: 0.25rem; }
     .run-meta { font-size: 0.85rem; color: #8b949e; }
 
-    .step { margin: 0.5rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid #21262d; }
+    .step { margin: 0.25rem 0; border-left: 3px solid #21262d; border-radius: 4px; }
     .step-succeeded { border-color: #238636; }
     .step-failed { border-color: #da3633; }
     .step-in_progress { border-color: #d29922; }
-    .step-name { font-weight: 600; font-size: 0.9rem; }
-    .step-meta { font-size: 0.8rem; color: #8b949e; }
+    .step-header {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 0.75rem;
+      cursor: pointer;
+      user-select: none;
+      transition: background 0.15s;
+    }
+    .step-header:hover { background: #161b22; }
+    .step-header .chevron {
+      font-size: 0.7rem;
+      color: #484f58;
+      transition: transform 0.15s;
+      flex-shrink: 0;
+    }
+    .step.open .chevron { transform: rotate(90deg); }
+    .step-name { font-weight: 600; font-size: 0.9rem; flex: 1; }
+    .step-meta { font-size: 0.8rem; color: #8b949e; flex-shrink: 0; }
+    .step-body { display: none; }
+    .step.open .step-body { display: block; }
 
     .logs {
-      margin-top: 1rem;
+      margin: 0;
       background: #161b22;
-      border: 1px solid #21262d;
-      border-radius: 6px;
+      border-top: 1px solid #21262d;
       padding: 0.75rem;
       max-height: 600px;
       overflow-y: auto;
@@ -78,6 +151,35 @@ export function layout(title: string, content: HtmlEscapedString) {
       line-height: 1.4;
     }
     .log-line { color: #c9d1d9; }
+
+    .workflow-list { display: flex; flex-direction: column; gap: 0.75rem; }
+    .workflow-card {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 1rem 1.25rem;
+      border: 1px solid #21262d;
+      border-radius: 6px;
+      background: #161b22;
+    }
+    .workflow-card:hover { border-color: #30363d; }
+    .workflow-name { font-weight: 600; font-size: 1rem; }
+    .workflow-file { font-size: 0.8rem; color: #8b949e; margin-top: 0.15rem; }
+    .workflow-jobs { font-size: 0.8rem; color: #8b949e; margin-top: 0.25rem; }
+    .workflow-triggers { display: flex; gap: 0.5rem; flex-wrap: wrap; flex-shrink: 0; margin-left: 1rem; }
+    .trigger-btn {
+      background: #21262d;
+      color: #c9d1d9;
+      border: 1px solid #30363d;
+      border-radius: 6px;
+      padding: 0.35rem 0.75rem;
+      font-size: 0.8rem;
+      cursor: pointer;
+      transition: background 0.15s, border-color 0.15s;
+      font-family: inherit;
+    }
+    .trigger-btn:hover { background: #30363d; border-color: #484f58; }
+    .trigger-btn.triggered { background: #238636; border-color: #238636; color: #fff; }
 
     .empty { text-align: center; padding: 3rem; color: #8b949e; }
 
@@ -91,15 +193,37 @@ export function layout(title: string, content: HtmlEscapedString) {
 <body>
   <header>
     <div class="container">
-      <h1>localrunner</h1>
+      <h1><a href="/" style="color: inherit;">localrunner</a></h1>
       <nav>
-        <a href="/">Runs</a>
+        <a href="/workflows">Workflows</a>
       </nav>
     </div>
   </header>
   <div class="container">
     ${content}
   </div>
+  <script>
+    // Track user-toggled steps so state survives SSE innerHTML swaps
+    const userToggles = new Map(); // stepId -> true (open) | false (closed)
+
+    document.addEventListener('click', (e) => {
+      const header = e.target.closest('.step-header');
+      if (!header) return;
+      const step = header.parentElement;
+      step.classList.toggle('open');
+      const id = step.dataset.stepId;
+      if (id) userToggles.set(id, step.classList.contains('open'));
+    });
+
+    // After HTMX swaps new HTML in, re-apply any user overrides
+    document.addEventListener('htmx:afterSwap', () => {
+      for (const [id, isOpen] of userToggles) {
+        const el = document.querySelector('[data-step-id="' + id + '"]');
+        if (!el) continue;
+        el.classList.toggle('open', isOpen);
+      }
+    });
+  </script>
 </body>
 </html>`;
 }

--- a/web/routes.ts
+++ b/web/routes.ts
@@ -1,14 +1,18 @@
 import type { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
+import { join, resolve, basename } from "path";
 import { layout } from "./layout";
 import { runsPage, runsTable } from "./runs";
 import { runDetailPage, runDetailContent } from "./run-detail";
+import { workflowsPage } from "./workflows";
+import { triggerWorkflow } from "./trigger";
 import { getDb } from "../db";
-import { runs, jobs, steps, stepLogs } from "../db/schema";
+import { runs, jobs, steps, stepLogs, artifacts } from "../db/schema";
 import { eq, desc } from "drizzle-orm";
+import { parseWorkflow, normalizeOn } from "../workflow";
 import type { RunManager } from "../server/runs";
 
-export function registerWebRoutes(app: Hono, runManager: RunManager) {
+export function registerWebRoutes(app: Hono, runManager: RunManager, port: number) {
   // Dashboard — list of recent runs
   app.get("/", (c) => {
     const db = getDb();
@@ -30,7 +34,7 @@ export function registerWebRoutes(app: Hono, runManager: RunManager) {
     if (!data) return c.html(layout("Not Found", runsPage([])), 404);
     return c.html(layout(
       `${data.run.workflowName || "Run"} — ${data.run.jobName || ""}`,
-      runDetailPage(data.run, data.jobs, data.steps, data.logs),
+      runDetailPage(data.run, data.jobs, data.steps, data.logs, data.artifacts),
     ));
   });
 
@@ -39,7 +43,7 @@ export function registerWebRoutes(app: Hono, runManager: RunManager) {
     const runId = c.req.param("id");
     const data = loadRunDetail(runId);
     if (!data) return c.text("Not found", 404);
-    return c.html(runDetailContent(data.run, data.jobs, data.steps, data.logs));
+    return c.html(runDetailContent(data.run, data.jobs, data.steps, data.logs, data.artifacts));
   });
 
   // SSE stream for the runs list page — notifies when any run changes
@@ -64,6 +68,28 @@ export function registerWebRoutes(app: Hono, runManager: RunManager) {
         }, 1000);
       });
     });
+  });
+
+  // Workflows page — discover and trigger workflows
+  app.get("/workflows", async (c) => {
+    const workflows = await discoverWorkflows();
+    return c.html(layout("Workflows", workflowsPage(workflows)));
+  });
+
+  // Trigger a workflow run
+  app.post("/api/trigger", async (c) => {
+    const body = await c.req.parseBody();
+    const fileName = body.fileName as string;
+    const event = body.event as string;
+    if (!fileName || !event) return c.text("Missing fileName or event", 400);
+
+    try {
+      const { runId } = await triggerWorkflow(fileName, event, port, runManager);
+      c.header("HX-Redirect", `/runs/${runId}`);
+      return c.text("ok");
+    } catch (err) {
+      return c.text(`Trigger failed: ${(err as Error).message}`, 500);
+    }
   });
 
   // SSE stream for a single run — notifies on step/log/job changes
@@ -105,6 +131,32 @@ export function registerWebRoutes(app: Hono, runManager: RunManager) {
   });
 }
 
+async function discoverWorkflows() {
+  const workflowDir = resolve(".github/workflows");
+  const glob = new Bun.Glob("*.{yml,yaml}");
+  const results: { fileName: string; name: string; events: string[]; jobs: string[] }[] = [];
+
+  try {
+    for await (const file of glob.scan({ cwd: workflowDir })) {
+      try {
+        const text = await Bun.file(join(workflowDir, file)).text();
+        const workflow = parseWorkflow(text);
+        const events = Object.keys(normalizeOn(workflow.on));
+        const jobNames = Object.keys(workflow.jobs);
+        results.push({
+          fileName: file,
+          name: workflow.name || basename(file, ".yml"),
+          events,
+          jobs: jobNames,
+        });
+      } catch {}
+    }
+  } catch {}
+
+  results.sort((a, b) => a.name.localeCompare(b.name));
+  return results;
+}
+
 function loadRunDetail(runId: string) {
   const db = getDb();
   const run = db.select().from(runs).where(eq(runs.id, runId)).get();
@@ -123,5 +175,7 @@ function loadRunDetail(runId: string) {
     }
   }
 
-  return { run, jobs: runJobs, steps: allSteps, logs: allLogs };
+  const runArtifacts = db.select().from(artifacts).where(eq(artifacts.runId, runId)).all();
+
+  return { run, jobs: runJobs, steps: allSteps, logs: allLogs, artifacts: runArtifacts };
 }

--- a/web/run-detail.ts
+++ b/web/run-detail.ts
@@ -41,6 +41,13 @@ interface StepLog {
   content: string | null;
 }
 
+interface Artifact {
+  id: number;
+  name: string;
+  size: number;
+  finalized: number;
+}
+
 function badge(status: string | null, conclusion: string | null) {
   if (status === "completed" && conclusion) {
     return html`<span class="badge badge-${conclusion}">${conclusion}</span>`;
@@ -59,11 +66,23 @@ function duration(start: number | null, end: number | null): string {
   return `${Math.floor(elapsed / 60000)}m ${Math.floor((elapsed % 60000) / 1000)}s`;
 }
 
-export function runDetailPage(run: Run, jobs: Job[], steps: Step[], logs: StepLog[]) {
+function dotClass(status: string | null, conclusion: string | null): string {
+  if (status === "completed" && conclusion) return `dot-${conclusion}`;
+  if (status) return `dot-${status}`;
+  return "dot-queued";
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function runDetailPage(run: Run, jobs: Job[], steps: Step[], logs: StepLog[], artifacts: Artifact[]) {
   const isActive = run.status === "in_progress" || run.status === "queued";
 
   if (!isActive) {
-    return html`<div>${runDetailContent(run, jobs, steps, logs)}</div>`;
+    return html`<div>${runDetailContent(run, jobs, steps, logs, artifacts)}</div>`;
   }
 
   return html`
@@ -74,12 +93,12 @@ export function runDetailPage(run: Run, jobs: Job[], steps: Step[], logs: StepLo
       hx-trigger="sse:run_changed"
       hx-swap="innerHTML"
     >
-      ${runDetailContent(run, jobs, steps, logs)}
+      ${runDetailContent(run, jobs, steps, logs, artifacts)}
     </div>
   `;
 }
 
-export function runDetailContent(run: Run, jobs: Job[], steps: Step[], logs: StepLog[]) {
+export function runDetailContent(run: Run, jobs: Job[], steps: Step[], logs: StepLog[], artifacts: Artifact[]) {
   const logsByStep = new Map<number, StepLog[]>();
   for (const log of logs) {
     if (log.stepId == null) continue;
@@ -99,33 +118,66 @@ export function runDetailContent(run: Run, jobs: Job[], steps: Step[], logs: Ste
       </div>
     </div>
 
-    ${jobs.map((job) => {
-      const jobSteps = steps
-        .filter((s) => s.jobId === job.id)
-        .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0));
-
-      return html`
-        <div class="run-detail">
-          <h3>${job.name || "Job"} ${badge(job.status, job.conclusion)}</h3>
-
-          ${jobSteps.map((step) => {
-            const stepClass = step.conclusion || step.status || "";
-            const stepLogs = logsByStep.get(step.id) || [];
-            stepLogs.sort((a, b) => (a.lineNumber ?? 0) - (b.lineNumber ?? 0));
-
-            return html`
-              <div class="step step-${stepClass}">
-                <div class="step-name">${step.name || "Step"} ${badge(step.status, step.conclusion)}</div>
-                <div class="step-meta">${duration(step.startedAt, step.completedAt)}</div>
-                ${stepLogs.length > 0
-                  ? html`<div class="logs">${stepLogs.map((l) => html`<div class="log-line">${l.content || ""}</div>`)}</div>`
-                  : html``
-                }
-              </div>
-            `;
-          })}
+    <div class="run-layout">
+      <nav class="run-sidebar">
+        <div class="sidebar-section">
+          <h4>Jobs</h4>
+          ${jobs.map((job) => html`
+            <a class="sidebar-job" href="#job-${job.id}">
+              <span class="status-dot ${dotClass(job.status, job.conclusion)}"></span>
+              ${job.name || "Job"}
+            </a>
+          `)}
         </div>
-      `;
-    })}
+
+        ${artifacts.length > 0 ? html`
+          <div class="sidebar-section">
+            <h4>Artifacts</h4>
+            ${artifacts.map((a) => html`
+              <div class="sidebar-artifact">
+                <span>${a.name}</span>
+                <span class="artifact-size">${formatSize(a.size)}</span>
+              </div>
+            `)}
+          </div>
+        ` : html``}
+      </nav>
+
+      <div class="run-main">
+        ${jobs.map((job) => {
+          const jobSteps = steps
+            .filter((s) => s.jobId === job.id)
+            .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0));
+
+          return html`
+            <div class="run-detail" id="job-${job.id}">
+              <h3>${job.name || "Job"} ${badge(job.status, job.conclusion)}</h3>
+
+              ${jobSteps.map((step) => {
+                const stepClass = step.conclusion || step.status || "";
+                const stepLogs = logsByStep.get(step.id as any) || [];
+                stepLogs.sort((a, b) => (a.lineNumber ?? 0) - (b.lineNumber ?? 0));
+
+                const collapsed = step.conclusion === "succeeded" || step.conclusion === "skipped";
+                return html`
+                  <div class="step step-${stepClass}${collapsed ? "" : " open"}" data-step-id="${step.id}">
+                    <div class="step-header">
+                      <span class="chevron">&#9654;</span>
+                      <span class="step-name">${step.name || "Step"}</span>
+                      ${badge(step.status, step.conclusion)}
+                      <span class="step-meta">${duration(step.startedAt, step.completedAt)}</span>
+                    </div>
+                    ${stepLogs.length > 0
+                      ? html`<div class="step-body"><div class="logs">${stepLogs.map((l) => html`<div class="log-line">${l.content || ""}</div>`)}</div></div>`
+                      : html``
+                    }
+                  </div>
+                `;
+              })}
+            </div>
+          `;
+        })}
+      </div>
+    </div>
   `;
 }

--- a/web/trigger.ts
+++ b/web/trigger.ts
@@ -1,0 +1,135 @@
+import { resolve, join, basename } from "path";
+import { getRepoContext } from "../context";
+import { parseWorkflow, normalizeOn, workflowStepsToRunnerSteps } from "../workflow";
+import { generateEventPayload } from "../events";
+import { scriptStep, actionStep } from "../server/steps";
+import { buildExpressionContext, evaluateExpressions } from "../expressions";
+import { resolveSecrets, scanRequiredSecrets } from "../secrets";
+import { resolveVariables } from "../variables";
+import { expandMatrix } from "../matrix";
+import { OutputHandler } from "../output";
+import { launchRunner, type RunConfig } from "../orchestrator";
+import type { RunManager } from "../server/runs";
+
+const DEFAULT_IMAGES: Record<string, string> = {
+  "ubuntu-latest": "ghcr.io/camdenclark/localrunner:ubuntu24",
+  "ubuntu-24.04": "ghcr.io/camdenclark/localrunner:ubuntu24",
+  "ubuntu-22.04": "ghcr.io/camdenclark/localrunner:ubuntu22",
+};
+
+function resolveDockerImage(runsOn: string | string[] | undefined): string | undefined {
+  const label = Array.isArray(runsOn) ? runsOn[0] : runsOn;
+  const key = label || "ubuntu-latest";
+  return DEFAULT_IMAGES[key] || DEFAULT_IMAGES["ubuntu-latest"];
+}
+
+/**
+ * Trigger a workflow run from the web UI.
+ * Replicates the core CLI flow: parse workflow, resolve context, register run, launch runner.
+ */
+export async function triggerWorkflow(
+  fileName: string,
+  eventName: string,
+  port: number,
+  runManager: RunManager,
+): Promise<{ runId: string }> {
+  const workflowDir = resolve(".github/workflows");
+  const fullPath = join(workflowDir, fileName);
+  const text = await Bun.file(fullPath).text();
+  const workflow = parseWorkflow(text);
+  const workflowName = workflow.name || basename(fileName, ".yml");
+
+  const repoCtx = await getRepoContext();
+
+  // Select first job with steps
+  const jobNames = Object.keys(workflow.jobs);
+  const selectedJobName = jobNames.find((n) => {
+    const j = workflow.jobs[n];
+    return j && j.steps && j.steps.length > 0;
+  }) || jobNames[0]!;
+  const selectedJob = workflow.jobs[selectedJobName]!;
+
+  // Resolve secrets and variables
+  const secrets = await resolveSecrets({
+    token: repoCtx.token,
+    yamlText: text,
+  });
+  const variables = await resolveVariables({});
+
+  // Event payload
+  let inputDefaults: Record<string, string> | undefined;
+  if (eventName === "workflow_dispatch") {
+    const onConfig = normalizeOn(workflow.on);
+    const dispatchConfig = onConfig["workflow_dispatch"] as { inputs?: Record<string, { default?: string }> } | null;
+    if (dispatchConfig?.inputs) {
+      inputDefaults = {};
+      for (const [key, config] of Object.entries(dispatchConfig.inputs)) {
+        if (config?.default !== undefined) {
+          inputDefaults[key] = String(config.default);
+        }
+      }
+    }
+  }
+  const eventPayload = await generateEventPayload(eventName, repoCtx, undefined, inputDefaults);
+
+  // Matrix — use first combo or none
+  const matrixConfig = selectedJob.strategy?.matrix;
+  const matrixCombinations = expandMatrix(matrixConfig);
+  const matrixCombo = matrixCombinations.length > 0 ? matrixCombinations[0] : undefined;
+
+  // Build expression context and convert steps
+  const exprCtx = buildExpressionContext(
+    repoCtx, eventName, eventPayload, workflowName, selectedJobName,
+    undefined, secrets, variables, matrixCombo,
+  );
+
+  const jobSteps = workflowStepsToRunnerSteps(
+    selectedJob.steps!,
+    (script, displayName) => scriptStep(evaluateExpressions(script, exprCtx), displayName),
+    (action, ref, displayName, inputs) => {
+      const evaluated = inputs
+        ? Object.fromEntries(Object.entries(inputs).map(([k, v]) => [k, evaluateExpressions(v, exprCtx)]))
+        : undefined;
+      return actionStep(action, ref, displayName, evaluated);
+    },
+  );
+
+  const dockerImage = resolveDockerImage(selectedJob["runs-on"]);
+  const isDocker = !!dockerImage;
+  const hostAddress = isDocker ? "host.docker.internal" : "localhost";
+
+  // Register the run
+  const output = new OutputHandler("verbose");
+  const { ctx, jobCompleted } = runManager.registerRun({
+    port,
+    repoCtx,
+    jobSteps,
+    eventName,
+    eventPayload,
+    workflowName,
+    jobName: selectedJobName,
+    secrets,
+    variables,
+    matrix: matrixCombo,
+    hostAddress,
+    runnerOs: isDocker ? "Linux" : "macOS",
+    runnerArch: isDocker ? "X64" : "ARM64",
+    output,
+  });
+
+  // Launch runner in the background
+  const runnerDir = resolve(import.meta.dir, "..", "runner");
+  launchRunner({
+    port,
+    hostAddress,
+    dockerImage,
+    runnerDir,
+    eventPayload,
+    services: selectedJob.services,
+    output,
+    jobCompleted,
+    onComplete: () => runManager.completeRun(ctx.runId),
+  }).catch(() => runManager.completeRun(ctx.runId));
+
+  return { runId: ctx.runId };
+}

--- a/web/workflows.ts
+++ b/web/workflows.ts
@@ -1,0 +1,39 @@
+import { html } from "hono/html";
+
+interface WorkflowInfo {
+  fileName: string;
+  name: string;
+  events: string[];
+  jobs: string[];
+}
+
+export function workflowsPage(workflows: WorkflowInfo[]) {
+  if (workflows.length === 0) {
+    return html`<div class="empty">No workflows found in <code>.github/workflows/</code></div>`;
+  }
+
+  return html`
+    <div class="workflow-list">
+      ${workflows.map((wf) => html`
+        <div class="workflow-card">
+          <div class="workflow-info">
+            <div class="workflow-name">${wf.name}</div>
+            <div class="workflow-file">${wf.fileName}</div>
+            <div class="workflow-jobs">${wf.jobs.length} job${wf.jobs.length !== 1 ? "s" : ""}: ${wf.jobs.join(", ")}</div>
+          </div>
+          <div class="workflow-triggers">
+            ${wf.events.map((event) => html`
+              <button
+                class="trigger-btn"
+                hx-post="/api/trigger"
+                hx-vals='${JSON.stringify({ fileName: wf.fileName, event })}'
+                hx-swap="none"
+                onclick="this.classList.add('triggered'); this.textContent='triggered…'; setTimeout(() => { this.classList.remove('triggered'); this.textContent='${event}'; }, 2000)"
+              >${event}</button>
+            `)}
+          </div>
+        </div>
+      `)}
+    </div>
+  `;
+}


### PR DESCRIPTION
## Summary
- **Run detail page**: sidebar with job navigation (status dots + anchor links) and artifacts; collapsible steps that auto-collapse on success and persist user toggle state across live SSE updates
- **Fix step persistence**: migration to convert `steps.id` and `step_logs.step_id` from integer to text, fixing the schema mismatch from the consistent-UUIDs commit that silently broke step/log storage
- **Workflows page** (`/workflows`): discovers `.github/workflows/` files, shows each with trigger buttons for every event type; triggers run the full CLI flow server-side and redirect to the live run detail page

## Test plan
- [x] `bun test` — 102 tests pass
- [ ] Start server with `bun serve.ts`, navigate to `/workflows`, trigger a workflow, verify redirect to live run detail page
- [ ] Verify steps and logs now persist for new runs (the migration fix)
- [ ] On run detail page: verify sidebar shows jobs with status dots, collapsible steps work, succeeded steps auto-collapse
- [ ] Toggle a step open, wait for SSE update, verify it stays open

🤖 Generated with [Claude Code](https://claude.com/claude-code)