### PR TITLE
Fix event payload array serialization

### DIFF
--- a/context.ts
+++ b/context.ts
@@ -76,12 +76,20 @@ export async function getRepoContext(): Promise<RepoContext> {
 }
 
 // Serialize an event payload object into the {t, d} context format
+function serializeEventValue(v: any): any {
+  if (v === null || v === undefined) return "";
+  if (Array.isArray(v)) {
+    return { t: 1, seq: v.map(serializeEventValue) };
+  }
+  if (v && typeof v === "object") {
+    return serializeEventPayload(v);
+  }
+  return v;
+}
+
 function serializeEventPayload(payload: object): { t: number; d: any[] } {
   const entries = Object.entries(payload).map(([k, v]) => {
-    if (v && typeof v === "object" && !Array.isArray(v)) {
-      return { k, v: serializeEventPayload(v) };
-    }
-    return { k, v };
+    return { k, v: serializeEventValue(v) };
   });
   return { t: 2, d: entries };
 }

--- a/events.ts
+++ b/events.ts
@@ -209,8 +209,11 @@ export const EVENT_DEFINITIONS: EventDefinition[] = [
     ],
     supportsFilters: noFilters,
     generatePayload: (ctx) => entityPayload(ctx, "opened", "issue", {
-      number: 1, title: "Test issue", state: "open",
+      number: 1, title: "Test issue", body: "", state: "open",
       html_url: `${ctx.serverUrl}/${ctx.fullName}/issues/1`,
+      labels: [], assignees: [], comments: 0, locked: false,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
       user: senderPayload(ctx),
     }),
   },

--- a/server/steps.ts
+++ b/server/steps.ts
@@ -27,14 +27,14 @@ export function scriptStep(
     displayName: displayName || `Run ${script.slice(0, 40)}`,
     contextName: `run_${randomUUID().slice(0, 8)}`,
     condition: resolveCondition(opts?.condition),
-    continueOnError: opts?.continueOnError ?? false,
-    environment: opts?.environment
-      ? { type: 2, map: Object.entries(opts.environment).map(([k, v]) => ({ Key: k, Value: v })) }
-      : { type: 2, map: [] },
     inputs: {
       type: 2,
       map: [{ Key: "script", Value: script }],
     },
+    ...(opts?.environment ? {
+      environment: { type: 2, map: Object.entries(opts.environment).map(([k, v]) => ({ Key: k, Value: v })) },
+    } : {}),
+    ...(opts?.continueOnError ? { continueOnError: true } : {}),
   };
 }
 
@@ -71,13 +71,13 @@ export function actionStep(
     displayName: displayName || `Run ${action}@${ref}`,
     contextName: action.replace(/[^a-zA-Z0-9]/g, "_"),
     condition: resolveCondition(opts?.condition),
-    continueOnError: opts?.continueOnError ?? false,
-    environment: opts?.environment
-      ? { type: 2, map: Object.entries(opts.environment).map(([k, v]) => ({ Key: k, Value: v })) }
-      : { type: 2, map: [] },
     inputs: {
       type: 2,
       map: inputMap,
     },
+    ...(opts?.environment ? {
+      environment: { type: 2, map: Object.entries(opts.environment).map(([k, v]) => ({ Key: k, Value: v })) },
+    } : {}),
+    ...(opts?.continueOnError ? { continueOnError: true } : {}),
   };
 }


### PR DESCRIPTION
## Summary
- **Fix array serialization in event payloads**: `serializeEventPayload` was passing arrays through as raw JS values instead of encoding them as template sequence tokens (`{ t: 1, seq: [...] }`). This caused the runner to reject the entire `acquirejob` response when event payloads contained array fields (e.g. `issues.labels`, `issues.assignees`).
- **Enrich issues event payload**: Added missing fields (`body`, `labels`, `assignees`, `comments`, `locked`, `created_at`, `updated_at`) to match real GitHub payloads.
- **Harden step field emission**: Only emit `continueOnError` and `environment` on steps when actually set, rather than always including defaults.

## Test plan
- [x] `bun test` passes (115 tests)
- [x] `issues` event workflow runs successfully with payload field access, conditionals, and env vars from event data
- [x] `push` event workflow with step `if` conditions still works
- [x] Step `if: github.event.action == 'labeled'` correctly skips when action is `opened`

🤖 Generated with [Claude Code](https://claude.com/claude-code)