### PR TITLE
Render GitHub Actions annotations in terminal and web UI

### DIFF
--- a/output.test.ts
+++ b/output.test.ts
@@ -1,0 +1,148 @@
+import { test, expect, describe, beforeEach, afterEach, spyOn } from "bun:test";
+import { OutputHandler } from "./output";
+
+// Capture console.log output
+function captureOutput(handler: OutputHandler, fn: () => void): string[] {
+  const lines: string[] = [];
+  const spy = spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+    lines.push(args.map(String).join(" "));
+  });
+  const writeSpy = spyOn(process.stdout, "write").mockImplementation((data: string | Uint8Array) => {
+    // capture stdout.write too (used by pretty mode)
+    return true;
+  });
+  fn();
+  spy.mockRestore();
+  writeSpy.mockRestore();
+  return lines;
+}
+
+describe("annotation rendering", () => {
+  describe("verbose mode", () => {
+    test("renders ##[warning] with color and tag", () => {
+      const handler = new OutputHandler("verbose");
+      const lines = captureOutput(handler, () => {
+        handler.emit({ type: "step_start", stepName: "Test", timestamp: 0 });
+        handler.emit({ type: "step_log", line: "##[warning]Cache miss" });
+      });
+      const logLine = lines.find((l) => l.includes("warning"));
+      expect(logLine).toBeDefined();
+      expect(logLine).toContain("[warning]");
+      expect(logLine).toContain("Cache miss");
+      expect(logLine).toContain("\x1b[33m"); // yellow
+    });
+
+    test("renders ##[error] with color and tag", () => {
+      const handler = new OutputHandler("verbose");
+      const lines = captureOutput(handler, () => {
+        handler.emit({ type: "step_start", stepName: "Test", timestamp: 0 });
+        handler.emit({ type: "step_log", line: "##[error]Build failed" });
+      });
+      const logLine = lines.find((l) => l.includes("error"));
+      expect(logLine).toBeDefined();
+      expect(logLine).toContain("[error]");
+      expect(logLine).toContain("Build failed");
+      expect(logLine).toContain("\x1b[31m"); // red
+    });
+
+    test("renders ##[notice] with color and tag", () => {
+      const handler = new OutputHandler("verbose");
+      const lines = captureOutput(handler, () => {
+        handler.emit({ type: "step_start", stepName: "Test", timestamp: 0 });
+        handler.emit({ type: "step_log", line: "##[notice]Deployment complete" });
+      });
+      const logLine = lines.find((l) => l.includes("notice"));
+      expect(logLine).toBeDefined();
+      expect(logLine).toContain("[notice]");
+      expect(logLine).toContain("Deployment complete");
+    });
+
+    test("renders ##[group] with bold", () => {
+      const handler = new OutputHandler("verbose");
+      const lines = captureOutput(handler, () => {
+        handler.emit({ type: "step_start", stepName: "Test", timestamp: 0 });
+        handler.emit({ type: "step_log", line: "##[group]Run bun install" });
+      });
+      const logLine = lines.find((l) => l.includes("group"));
+      expect(logLine).toBeDefined();
+      expect(logLine).toContain("Run bun install");
+    });
+
+    test("renders ##[endgroup]", () => {
+      const handler = new OutputHandler("verbose");
+      const lines = captureOutput(handler, () => {
+        handler.emit({ type: "step_start", stepName: "Test", timestamp: 0 });
+        handler.emit({ type: "step_log", line: "##[endgroup]" });
+      });
+      const logLine = lines.find((l) => l.includes("endgroup"));
+      expect(logLine).toBeDefined();
+    });
+
+    test("renders [command] without ## prefix", () => {
+      const handler = new OutputHandler("verbose");
+      const lines = captureOutput(handler, () => {
+        handler.emit({ type: "step_start", stepName: "Test", timestamp: 0 });
+        handler.emit({ type: "step_log", line: "[command]/usr/bin/tar -xf archive.tar" });
+      });
+      const logLine = lines.find((l) => l.includes("tar"));
+      expect(logLine).toBeDefined();
+      expect(logLine).toContain("[command]");
+      expect(logLine).toContain("/usr/bin/tar -xf archive.tar");
+      expect(logLine).toContain("\x1b[90m"); // dim
+    });
+
+    test("passes through non-annotation lines unchanged", () => {
+      const handler = new OutputHandler("verbose");
+      const lines = captureOutput(handler, () => {
+        handler.emit({ type: "step_start", stepName: "Test", timestamp: 0 });
+        handler.emit({ type: "step_log", line: "normal log line" });
+      });
+      const logLine = lines.find((l) => l.includes("normal log line"));
+      expect(logLine).toBeDefined();
+      expect(logLine).toContain("[log] normal log line");
+    });
+  });
+
+  describe("raw mode", () => {
+    test("passes annotations through unchanged", () => {
+      const handler = new OutputHandler("raw");
+      const lines = captureOutput(handler, () => {
+        handler.emit({ type: "step_start", stepName: "Test", timestamp: 0 });
+        handler.emit({ type: "step_log", line: "##[warning]Cache miss" });
+      });
+      expect(lines).toContain("##[warning]Cache miss");
+    });
+  });
+
+  describe("pretty mode - failed step dump", () => {
+    test("formats annotations in failed step logs", () => {
+      const handler = new OutputHandler("pretty");
+      const lines = captureOutput(handler, () => {
+        handler.emit({ type: "step_start", stepName: "Build", timestamp: 0 });
+        handler.emit({ type: "step_log", line: "##[warning]Deprecated API" });
+        handler.emit({ type: "step_log", line: "##[error]Compilation failed" });
+        handler.emit({ type: "step_log", line: "normal output" });
+        handler.emit({ type: "step_log", line: "##[group]Details" });
+        handler.emit({ type: "step_log", line: "##[endgroup]" });
+        handler.emit({
+          type: "step_complete",
+          stepName: "Build",
+          conclusion: "failed",
+          timestamp: 1000,
+        });
+        handler.emit({ type: "job_complete", conclusion: "failed" });
+      });
+      const output = lines.join("\n");
+      // Should contain formatted warning (yellow)
+      expect(output).toContain("\x1b[33m");
+      expect(output).toContain("Deprecated API");
+      // Should contain formatted error (red)
+      expect(output).toContain("\x1b[31m");
+      expect(output).toContain("Compilation failed");
+      // Normal output should pass through
+      expect(output).toContain("normal output");
+      // endgroup should be suppressed
+      expect(output).not.toContain("endgroup");
+    });
+  });
+});

--- a/output.ts
+++ b/output.ts
@@ -22,6 +22,63 @@ interface StepRecord {
   logs: string[];
 }
 
+/** Parse GitHub Actions annotations. Handles `##[cmd]msg` and `[command]msg` formats. */
+function parseAnnotation(line: string): { type: string; message: string } | null {
+  const match = line.match(/^##\[(\w+)](.*)/);
+  if (match) return { type: match[1], message: match[2] };
+  const cmdMatch = line.match(/^\[command](.*)/);
+  if (cmdMatch) return { type: "command", message: cmdMatch[1] };
+  return null;
+}
+
+/** Format an annotation for colored terminal output. */
+function formatAnnotation(ann: { type: string; message: string }): string | null {
+  switch (ann.type) {
+    case "warning":
+      return `\x1b[33m⚠ ${ann.message}\x1b[0m`;
+    case "error":
+      return `\x1b[31m✖ ${ann.message}\x1b[0m`;
+    case "notice":
+      return `\x1b[36mℹ ${ann.message}\x1b[0m`;
+    case "debug":
+      return `\x1b[90m${ann.message}\x1b[0m`;
+    case "group":
+      return `\x1b[1m▸ ${ann.message}\x1b[0m`;
+    case "endgroup":
+      return null; // suppress
+    case "command":
+      return `\x1b[90m$ ${ann.message}\x1b[0m`;
+    case "section":
+      return null; // internal, suppress
+    default:
+      return ann.message;
+  }
+}
+
+/** Format an annotation for verbose mode with tag labels. */
+function formatAnnotationVerbose(ann: { type: string; message: string }): string | null {
+  switch (ann.type) {
+    case "warning":
+      return `\x1b[33m[warning] ${ann.message}\x1b[0m`;
+    case "error":
+      return `\x1b[31m[error] ${ann.message}\x1b[0m`;
+    case "notice":
+      return `\x1b[36m[notice] ${ann.message}\x1b[0m`;
+    case "debug":
+      return `\x1b[90m[debug] ${ann.message}\x1b[0m`;
+    case "group":
+      return `\x1b[1m[group] ${ann.message}\x1b[0m`;
+    case "endgroup":
+      return `[endgroup]`;
+    case "command":
+      return `\x1b[90m[command] ${ann.message}\x1b[0m`;
+    case "section":
+      return null;
+    default:
+      return `[${ann.type}] ${ann.message}`;
+  }
+}
+
 export class OutputHandler {
   mode: OutputMode;
   steps: Map<string, StepRecord> = new Map();
@@ -102,10 +159,17 @@ export class OutputHandler {
         this.print(`  [step] ${icon} ${event.stepName}: Completed (${event.conclusion})`);
         break;
       }
-      case "step_log":
+      case "step_log": {
         this.bufferStepLog(event.line);
-        this.print(`  [log] ${event.line}`);
+        const ann = parseAnnotation(event.line);
+        if (ann) {
+          const formatted = formatAnnotationVerbose(ann);
+          if (formatted !== null) this.print(`  [log] ${formatted}`);
+        } else {
+          this.print(`  [log] ${event.line}`);
+        }
         break;
+      }
       case "runner":
         this.print(`  [runner${event.stream === "stderr" ? ":err" : ""}] ${event.line}`);
         break;
@@ -194,6 +258,12 @@ export class OutputHandler {
     }
   }
 
+  private formatLogLine(line: string): string | null {
+    const ann = parseAnnotation(line);
+    if (ann) return formatAnnotation(ann);
+    return line;
+  }
+
   private dumpFailedStepLogs(): void {
     for (const [, step] of this.steps) {
       if (step.conclusion && step.conclusion !== "succeeded" && step.conclusion !== "skipped" && step.logs.length > 0) {
@@ -202,7 +272,8 @@ export class OutputHandler {
         console.log();
         console.log(`  ${header}${rule}`);
         for (const line of step.logs) {
-          console.log(`  ${line}`);
+          const formatted = this.formatLogLine(line);
+          if (formatted !== null) console.log(`  ${formatted}`);
         }
         console.log(`  ${"─".repeat(44)}`);
       }

--- a/web/layout.ts
+++ b/web/layout.ts
@@ -151,6 +151,12 @@ export function layout(title: string, content: HtmlEscapedString) {
       line-height: 1.4;
     }
     .log-line { color: #c9d1d9; }
+    .log-warning { color: #d29922; }
+    .log-error { color: #f85149; font-weight: 600; }
+    .log-notice { color: #58a6ff; }
+    .log-debug { color: #484f58; }
+    .log-group { color: #c9d1d9; font-weight: 600; }
+    .log-command { color: #484f58; }
 
     .workflow-list { display: flex; flex-direction: column; gap: 0.75rem; }
     .workflow-card {

--- a/web/run-detail.ts
+++ b/web/run-detail.ts
@@ -78,6 +78,37 @@ function formatSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
+/** Parse and render a log line, handling ##[annotation] syntax. */
+function renderLogLine(content: string) {
+  let match = content.match(/^##\[(\w+)](.*)/);
+  if (!match) match = content.match(/^\[command](.*)/);
+  if (!match) return html`<div class="log-line">${content}</div>`;
+  // Normalize [command] match to have same shape
+  if (match.length === 2) match = [match[0], "command", match[1]] as unknown as RegExpMatchArray;
+
+  const [, type, message] = match;
+  switch (type) {
+    case "warning":
+      return html`<div class="log-line log-warning">⚠ ${message}</div>`;
+    case "error":
+      return html`<div class="log-line log-error">✖ ${message}</div>`;
+    case "notice":
+      return html`<div class="log-line log-notice">ℹ ${message}</div>`;
+    case "debug":
+      return html`<div class="log-line log-debug">${message}</div>`;
+    case "group":
+      return html`<div class="log-line log-group">▸ ${message}</div>`;
+    case "endgroup":
+      return html``;
+    case "command":
+      return html`<div class="log-line log-command">$ ${message}</div>`;
+    case "section":
+      return html``;
+    default:
+      return html`<div class="log-line">${content}</div>`;
+  }
+}
+
 export function runDetailPage(run: Run, jobs: Job[], steps: Step[], logs: StepLog[], artifacts: Artifact[]) {
   const isActive = run.status === "in_progress" || run.status === "queued";
 
@@ -168,7 +199,7 @@ export function runDetailContent(run: Run, jobs: Job[], steps: Step[], logs: Ste
                       <span class="step-meta">${duration(step.startedAt, step.completedAt)}</span>
                     </div>
                     ${stepLogs.length > 0
-                      ? html`<div class="step-body"><div class="logs">${stepLogs.map((l) => html`<div class="log-line">${l.content || ""}</div>`)}</div></div>`
+                      ? html`<div class="step-body"><div class="logs">${stepLogs.map((l) => renderLogLine(l.content || ""))}</div></div>`
                       : html``
                     }
                   </div>


### PR DESCRIPTION
## Summary
- Parse `##[warning]`, `##[error]`, `##[notice]`, `##[group]`, `##[endgroup]`, `##[debug]`, and `[command]` annotations instead of showing raw markup
- Terminal: colored output with icons in verbose/pretty modes, passthrough in raw mode
- Web UI: styled log lines with appropriate colors matching GitHub dark theme

Closes #43

## Test plan
- [x] Unit tests for annotation parsing across all output modes (9 tests)
- [ ] Run a workflow with cache/install steps and verify annotations render correctly in terminal
- [ ] Check web viewer shows colored warnings/errors instead of raw `##[warning]` text

🤖 Generated with [Claude Code](https://claude.com/claude-code)